### PR TITLE
Bundled snakemake support

### DIFF
--- a/builder/builder/builder.py
+++ b/builder/builder/builder.py
@@ -593,6 +593,16 @@ class Model:
     def GetRuleNames(self) -> List[str]:
         return [n.rulename for n in self.nodes]
 
+    def LookupRuleName(self, name: str) -> Optional[str]:
+        for n in self.nodes:
+            if name == n.name:
+                return n.rulename
+        return None
+
+    def LookupRuleNames(self, names: List[str]) -> List[Optional[str]]:
+        """Lookup rule name given full name, can take a single string or list"""
+        return [self.LookupRuleName(name) for name in names]
+
 
 def YAMLToConfig(content: str) -> str:
     """Transcribes YAML to a (Snakemake readable) dictionary config syntax"""

--- a/builder/builder/tests/builder_workflow_test.py
+++ b/builder/builder/tests/builder_workflow_test.py
@@ -23,7 +23,7 @@ workflow_folder = "builder/tests/workflow_import_test"
 )
 def test_Workflow_Imports(name: Tuple[List[str], str]):
     modules, module_out = name
-    build, m = builder.BuildFromFile(
+    build, m, _ = builder.BuildFromFile(
         f"{workflow_folder}/workflow_imports/{modules}.json",
         singlefile=True,
         expand=True,

--- a/electron-app/src/handles.ts
+++ b/electron-app/src/handles.ts
@@ -20,7 +20,7 @@ export async function ProcessQuery(
     // backend process closes; either successfully (stdout return)
     // or with an error (stderr return)
     proc.on("close", () => {
-      console.log(`close: ${stdout}`);
+      console.log(`close: ${stdout} ${stderr}`);
       if (stdout === "")
         // Empty return, most likely a failure in python
         resolve({

--- a/electron-app/src/handles.ts
+++ b/electron-app/src/handles.ts
@@ -137,19 +137,29 @@ export async function builder_BuildAndRun(
   if (data["body"]["command"] !== "") {
     stdout_callback("Running workflow...");
     cmd_callback("cd " + data["body"]["workdir"]);
-    //cmd_callback(data["body"]["command"]);
-    const query = {
-      query: "runner/snakemake-run",
-      data: {
-        format: "Snakefile",
-        content: {
-          workdir: data["body"]["workdir"],
-          command: data["body"]["command"],
-        },
-      },
-    };
-    await RunWorkflow(event, query, stdout_callback, stderr_callback);
-    stdout_callback("Workflow complete.");
+    const backend = query["data"]["backend"];
+    let query_run = {};
+    switch (backend) {
+      case "builtin":
+        query_run = {
+          query: "runner/snakemake-run",
+          data: {
+            format: "Snakefile",
+            content: {
+              workdir: data["body"]["workdir"],
+              command: data["body"]["command"],
+            },
+          },
+        };
+        await RunWorkflow(event, query_run, stdout_callback, stderr_callback);
+        stdout_callback("Workflow complete.");
+        break;
+      case "system":
+        cmd_callback(data["body"]["command"]);
+        break;
+      default:
+        console.log("Unknown Snakemake backend requested: " + backend);
+    }
   } else {
     stdout_callback("No workflow command to run.");
   }

--- a/electron-app/src/python/backend.py
+++ b/electron-app/src/python/backend.py
@@ -1,7 +1,9 @@
-# import base64
 import contextlib
 import json
+import logging
+import os
 import sys
+import tempfile
 
 import filesystem
 
@@ -9,8 +11,17 @@ import builder
 import runner
 
 
-default_build_path = "workflows/build"
-default_testbuild_path = "workflows/testbuild"
+default_build_path = tempfile.gettempdir() + "/workflows/build"
+default_testbuild_path = tempfile.gettempdir() + "/workflows/testbuild"
+logfile = os.path.expanduser("~") + "/GRAPEVNE.log"
+
+# Set up logging
+logging.basicConfig(
+    filename=logfile,
+    encoding="utf-8",
+    level=logging.DEBUG,
+)
+logging.info("Working directory: %s", os.getcwd())
 
 
 def post(request):
@@ -19,127 +30,144 @@ def post(request):
     query = request_js["query"]
     data = request_js["data"]
 
-    # File system queries
-    if query == "display/folderinfo":
-        data = {
-            "query": query,
-            "body": json.dumps(filesystem.GetFolderItems(data)),
-        }
+    logging.info("Received query: %s", query)
+    logging.info("Received data: %s", data)
 
-    # Builder queries
-    elif query == "builder/compile-to-json":
-        js = data["content"]
-        with open("workflow.json", "w") as f:  # dump config file to disk for debug
-            json.dump(js, f, indent=4)
-        memory_zip, _ = builder.BuildFromJSON(js, build_path=default_build_path)
-        # Binary return is not used when passing the information over stdout.
-        # Instead, the zip file is read back off the disk and forwarded by
-        # electron / nodejs.
-        data = {
-            "query": query,
-            "body": "",
-        }
-    elif query == "builder/build-and-run":
-        # First, build the workflow
-        js = data["content"]
-        with open("workflow.json", "w") as f:  # dump config file to disk for debug
-            json.dump(js, f, indent=4)
-        build_path = default_testbuild_path
-        memory_zip, _ = builder.BuildFromJSON(
-            js,
-            build_path=build_path,
-            clean_build=False,  # Do not overwrite existing build
-        )
-        # Second, return the launch command
-        data = runner.Launch_cmd(
-            {
-                "format": data["format"],
-                "content": build_path,
-                "args": data.get("args", ""),
-            },
-            terminal=False,
-        )
-        # Stringify command
-        data["command"] = " ".join(data["command"])
-        # Return the launch command
-        data = {
-            "query": query,
-            "body": data,
-        }
-    elif query == "builder/clean-build-folder":
-        data = {
-            "query": query,
-            "body": builder.CleanBuildFolder(default_testbuild_path),
-        }
-    elif query == "builder/get-remote-modules":
-        js = data["content"]
-        data = {
-            "query": query,
-            "body": builder.GetModulesList(js["url"]),
-        }
+    if query == "runner/snakemake-run":
+        # Special query - does not capture stdout, stderr
+        runner.SnakemakeRun(data)
+        return json.dumps({})
 
-    # Runner queries
-    elif query == "runner/build":
-        data = {
-            "query": query,
-            "body": runner.Build(data),
-        }
-    elif query == "runner/deleteresults":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.DeleteAllOutput(data)),
-        }
-    elif query == "runner/lint":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.LintContents(data)),
-        }
-    elif query == "runner/loadworkflow":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.LoadWorkflow(data)),
-        }
-    elif query == "runner/tokenize":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.Tokenize(data)),
-        }
-    elif query == "runner/tokenize_load":
-        try:
-            # Try full-tokenize (may fail if dependencies not present)
-            body = runner.FullTokenizeFromFile(data)
-        except BaseException:
-            # ...then try in-situ tokenization
-            body = runner.TokenizeFromFile(data)
-        data = {
-            "query": query,
-            "body": json.dumps(body),
-        }
-    elif query == "runner/jobstatus":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.TokenizeFromFile(data)),
-        }
-    elif query == "runner/launch":
-        data = {
-            "query": query,
-            "body": json.dumps(runner.Launch(data)),
-        }
-    elif query == "runner/check-node-dependencies":
-        data = {
-            "query": query,
-            "body": runner.CheckNodeDependencies(data),
-        }
+    # Suppress stdout as we only want to control the return data from this
+    # PyInstaller executable which is called from electron.
+    with contextlib.redirect_stdout(None):
+        # File system queries
+        if query == "display/folderinfo":
+            data = {
+                "query": query,
+                "body": json.dumps(filesystem.GetFolderItems(data)),
+            }
 
-    else:
-        raise NotImplementedError(f"Unknown query: {query}")
+        # Builder queries
+        elif query == "builder/compile-to-json":
+            js = data["content"]
+            # with open(default_build_path + "/workflow.json", "w") as f:  # dump config file to disk for debug
+            #     json.dump(js, f, indent=4)
+            memory_zip, _, zipfilename = builder.BuildFromJSON(
+                js,
+                build_path=default_build_path,
+            )
+            # Binary return is not used when passing the information over stdout.
+            # Instead, the zip file is read back off the disk and forwarded by
+            # electron / nodejs.
+            data = {
+                "query": query,
+                "body": {
+                    "zipfile": zipfilename,
+                },
+            }
+        elif query == "builder/build-and-run":
+            # First, build the workflow
+            logging.info("Building workflow")
+            js = data["content"]
+            # with open("workflow.json", "w") as f:  # dump config file to disk for debug
+            #     json.dump(js, f, indent=4)
+            build_path = default_testbuild_path
+            logging.info("BuildFromJSON")
+            memory_zip, _, _ = builder.BuildFromJSON(
+                js,
+                build_path=build_path,
+                clean_build=False,  # Do not overwrite existing build
+            )
+            # Second, return the launch command
+            logging.info("Generating launch command")
+            data = runner.Launch_cmd(
+                {
+                    "format": data["format"],
+                    "content": build_path,
+                    "args": data.get("args", ""),
+                },
+                terminal=False,
+            )
+            # Stringify command
+            data["command"] = " ".join(data["command"])
+            logging.info("Launch command: %s", data["command"])
+            # Return the launch command
+            data = {
+                "query": query,
+                "body": data,
+            }
+        elif query == "builder/clean-build-folder":
+            data = {
+                "query": query,
+                "body": builder.CleanBuildFolder(default_testbuild_path),
+            }
+        elif query == "builder/get-remote-modules":
+            js = data["content"]
+            data = {
+                "query": query,
+                "body": builder.GetModulesList(js["url"]),
+            }
+
+        # Runner queries
+        elif query == "runner/build":
+            data = {
+                "query": query,
+                "body": runner.Build(data),
+            }
+        elif query == "runner/deleteresults":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.DeleteAllOutput(data)),
+            }
+        elif query == "runner/lint":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.LintContents(data)),
+            }
+        elif query == "runner/loadworkflow":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.LoadWorkflow(data)),
+            }
+        elif query == "runner/tokenize":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.Tokenize(data)),
+            }
+        elif query == "runner/tokenize_load":
+            try:
+                # Try full-tokenize (may fail if dependencies not present)
+                body = runner.FullTokenizeFromFile(data)
+            except BaseException:
+                # ...then try in-situ tokenization
+                body = runner.TokenizeFromFile(data)
+            data = {
+                "query": query,
+                "body": json.dumps(body),
+            }
+        elif query == "runner/jobstatus":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.TokenizeFromFile(data)),
+            }
+        elif query == "runner/launch":
+            data = {
+                "query": query,
+                "body": json.dumps(runner.Launch(data)),
+            }
+        elif query == "runner/check-node-dependencies":
+            data = {
+                "query": query,
+                "body": runner.CheckNodeDependencies(data),
+            }
+
+        else:
+            raise NotImplementedError(f"Unknown query: {query}")
 
     return json.dumps(data)
 
 
-# Suppress stdout to prevent it being returned through python-shell
-# which is called from electron. This entire interface layer is only
-# required while the backend code is written in Python.
-with contextlib.redirect_stdout(None):
-    rtn = post(sys.argv[1])
-print(rtn)
+rtn = post(sys.argv[1])
+logging.info("Query response: %s", rtn)
+print(rtn)  # Return stringified JSON by stdout

--- a/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
+++ b/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
@@ -16,7 +16,7 @@ const RepoOptions: React.FC = () => {
   );
   const listingType = repoSettings.listing_type;
   const [repoURL, setRepoURL] = useState(repoSettings.repo);
-  
+
   const selectRepositoryTarget = (target) => {
     let repo = {};
     switch (target) {
@@ -57,23 +57,23 @@ const RepoOptions: React.FC = () => {
 
   return (
     <>
-    <div>
-      <select
-        defaultValue={listingType}
-        onChange={(e) => selectRepositoryTarget(e.target.value)}
-        style={{width: "100%"}}
-      >
-        <option value="LocalFilesystem">Local filesystem</option>
-        <option value="DirectoryListing">Directory Listing (Github)</option>
-        <option value="BranchListing">Branch Listing (Github)</option>
-      </select>
-    </div>
-    <input
-      type="text"
-      size={default_input_size}
-      value={repoURL}
-      onChange={(e) => handleChange(e.target.value)}
-    />
+      <div>
+        <select
+          defaultValue={listingType}
+          onChange={(e) => selectRepositoryTarget(e.target.value)}
+          style={{ width: "100%" }}
+        >
+          <option value="LocalFilesystem">Local filesystem</option>
+          <option value="DirectoryListing">Directory Listing (Github)</option>
+          <option value="BranchListing">Branch Listing (Github)</option>
+        </select>
+      </div>
+      <input
+        type="text"
+        size={default_input_size}
+        value={repoURL}
+        onChange={(e) => handleChange(e.target.value)}
+      />
     </>
   );
 };
@@ -81,7 +81,9 @@ const RepoOptions: React.FC = () => {
 const BuilderSettings = () => {
   const dispatch = useAppDispatch();
   const isvisible = useAppSelector((state) => state.builder.settings_visible);
-  const snakemake_backend = useAppSelector((state) => state.builder.snakemake_backend);
+  const snakemake_backend = useAppSelector(
+    (state) => state.builder.snakemake_backend
+  );
   const snakemake_args = useAppSelector(
     (state) => state.builder.snakemake_args
   );
@@ -110,14 +112,16 @@ const BuilderSettings = () => {
       >
         <br />
         <p>Repository</p>
-        <p><RepoOptions /></p>
+        <p>
+          <RepoOptions />
+        </p>
         <br />
         <p>Snakemake backend</p>
         <p>
           <select
             defaultValue={snakemake_backend}
             onChange={(e) => selectBackend(e.target.value)}
-            style={{width: "100%"}}
+            style={{ width: "100%" }}
           >
             <option value="builtin">Built-in</option>
             <option value="system">System</option>

--- a/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
+++ b/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch } from "redux/store/hooks";
 import { useAppSelector } from "redux/store/hooks";
 import { builderSetSnakemakeArgs } from "redux/actions";
 import { builderSetRepositoryTarget } from "redux/actions";
+import { builderSelectSnakemakeBackend } from "redux/actions";
 import { builderSetAutoValidateConnections } from "redux/actions";
 
 const default_input_size = 35;
@@ -13,38 +14,9 @@ const RepoOptions: React.FC = () => {
   const repoSettings = JSON.parse(
     useAppSelector((state) => state.builder.repo)
   );
+  const listingType = repoSettings.listing_type;
   const [repoURL, setRepoURL] = useState(repoSettings.repo);
-
-  const handleChange = (url) => {
-    const repo_settings = { ...repoSettings };
-    repo_settings.repo = url;
-    setRepoURL(url);
-    dispatch(builderSetRepositoryTarget(repo_settings));
-  };
-
-  return (
-    <input
-      type="text"
-      size={default_input_size}
-      value={repoURL}
-      onChange={(e) => handleChange(e.target.value)}
-    />
-  );
-};
-
-const BuilderSettings = () => {
-  const dispatch = useAppDispatch();
-  const isvisible = useAppSelector((state) => state.builder.settings_visible);
-  const listing_type = JSON.parse(
-    useAppSelector((state) => state.builder.repo)
-  ).listing_type;
-  const snakemake_args = useAppSelector(
-    (state) => state.builder.snakemake_args
-  );
-  const auto_validate_connections = useAppSelector(
-    (state) => state.builder.auto_validate_connections
-  );
-
+  
   const selectRepositoryTarget = (target) => {
     let repo = {};
     switch (target) {
@@ -52,7 +24,7 @@ const BuilderSettings = () => {
         repo = {
           type: "local",
           listing_type: "DirectoryListing",
-          repo: "../../snakeshack",
+          repo: "/Users/jsb/repos/jsbrittain/snakeshack",
         };
         break;
       case "DirectoryListing":
@@ -72,8 +44,50 @@ const BuilderSettings = () => {
       default:
         console.error("Unknown repository type selected: ", target);
     }
+    setRepoURL(repo["repo"]);
     dispatch(builderSetRepositoryTarget(repo));
   };
+
+  const handleChange = (url) => {
+    const repo_settings = { ...repoSettings };
+    repo_settings.repo = url;
+    setRepoURL(url);
+    dispatch(builderSetRepositoryTarget(repo_settings));
+  };
+
+  return (
+    <>
+    <div>
+      <select
+        defaultValue={listingType}
+        onChange={(e) => selectRepositoryTarget(e.target.value)}
+        style={{width: "100%"}}
+      >
+        <option value="LocalFilesystem">Local filesystem</option>
+        <option value="DirectoryListing">Directory Listing (Github)</option>
+        <option value="BranchListing">Branch Listing (Github)</option>
+      </select>
+    </div>
+    <input
+      type="text"
+      size={default_input_size}
+      value={repoURL}
+      onChange={(e) => handleChange(e.target.value)}
+    />
+    </>
+  );
+};
+
+const BuilderSettings = () => {
+  const dispatch = useAppDispatch();
+  const isvisible = useAppSelector((state) => state.builder.settings_visible);
+  const snakemake_backend = useAppSelector((state) => state.builder.snakemake_backend);
+  const snakemake_args = useAppSelector(
+    (state) => state.builder.snakemake_args
+  );
+  const auto_validate_connections = useAppSelector(
+    (state) => state.builder.auto_validate_connections
+  );
 
   const SetSnakemakeArgs = (args: string) => {
     dispatch(builderSetSnakemakeArgs(args));
@@ -83,6 +97,10 @@ const BuilderSettings = () => {
     dispatch(builderSetAutoValidateConnections(value));
   };
 
+  const selectBackend = (value: string) => {
+    dispatch(builderSelectSnakemakeBackend(value));
+  };
+
   return (
     <>
       <div
@@ -90,21 +108,21 @@ const BuilderSettings = () => {
           display: isvisible ? "block" : "none",
         }}
       >
+        <br />
         <p>Repository</p>
-        <div>
+        <p><RepoOptions /></p>
+        <br />
+        <p>Snakemake backend</p>
+        <p>
           <select
-            defaultValue={listing_type}
-            onChange={(e) => selectRepositoryTarget(e.target.value)}
-            style={{ width: "100%" }}
+            defaultValue={snakemake_backend}
+            onChange={(e) => selectBackend(e.target.value)}
+            style={{width: "100%"}}
           >
-            <option value="LocalFilesystem">Local filesystem</option>
-            <option value="DirectoryListing">Directory Listing (Github)</option>
-            <option value="BranchListing">Branch Listing (Github)</option>
+            <option value="builtin">Built-in</option>
+            <option value="system">System</option>
           </select>
-        </div>
-        <div>
-          <RepoOptions />
-        </div>
+        </p>
         <br />
         <p>Snakemake arguments</p>
         <p>

--- a/nodemapper/src/gui/MainPage.tsx
+++ b/nodemapper/src/gui/MainPage.tsx
@@ -55,12 +55,14 @@ const MainPage = () => {
             }}
           >
             GRAPEVNE
+            {/*
             <button className="btn" onClick={() => setMenuChoice(0)}>
               BUILDER
             </button>
             <button className="btn" onClick={() => setMenuChoice(1)}>
               RUNNER
             </button>
+            */}
           </div>
         </div>
         <div className="body" style={{ flex: "1 1 auto", overflowY: "auto" }}>

--- a/nodemapper/src/redux/actions/builder.ts
+++ b/nodemapper/src/redux/actions/builder.ts
@@ -22,6 +22,10 @@ export const builderToggleTerminalVisibility = createAction(
   "builder/toggle-terminal-visibility"
 );
 
+export const builderSetSettingsVisibility = createAction<boolean>(
+  "builder/set-settings-visibility"
+);
+
 export const builderToggleSettingsVisibility = createAction(
   "builder/toggle-settings-visibility"
 );
@@ -37,6 +41,10 @@ export const builderGetRemoteModules = createAction(
 );
 
 export const builderImportModule = createAction("builder/import-module");
+
+export const builderSelectSnakemakeBackend = createAction<string>(
+  "builder/select-snakemake-backend"
+);
 
 export const builderUpdateModulesList = createAction<string>(
   "builder/update-modules-list"

--- a/nodemapper/src/redux/middleware/builder.ts
+++ b/nodemapper/src/redux/middleware/builder.ts
@@ -12,6 +12,7 @@ import { builderNodeDeselected } from "redux/actions";
 import { builderUpdateNodeInfo } from "redux/actions";
 import { builderUpdateStatusText } from "redux/actions";
 import { builderUpdateModulesList } from "redux/actions";
+import { builderSetSettingsVisibility } from "redux/actions";
 
 const API_ENDPOINT = globals.getApiEndpoint();
 
@@ -35,7 +36,11 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           CompileToJSON();
           break;
         case "builder/build-and-run":
-          BuildAndRun(dispatch, getState().builder.snakemake_args);
+          BuildAndRun(
+            dispatch,
+            getState().builder.snakemake_args,
+            getState().builder.snakemake_backend,
+          );
           break;
         case "builder/clean-build-folder":
           CleanBuildFolder(dispatch);
@@ -47,14 +52,19 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           AddLink(
             action,
             getState().builder.auto_validate_connections,
-            dispatch
+            getState().builder.snakemake_backend,
+            dispatch,
           );
           break;
         case "builder/check-node-dependencies":
-          CheckNodeDependencies(action.payload, dispatch);
+          CheckNodeDependencies(
+            action.payload,
+            dispatch,
+            getState().builder.snakemake_backend,
+          );
           break;
         case "builder/node-selected":
-          NodeSelected(action, dispatch, getState);
+          NodeSelected(action, dispatch, dispatch, getState);
           break;
         case "builder/node-deselected":
           NodeDeselected(dispatch);
@@ -74,13 +84,28 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           );
           break;
         case "builder/get-remote-modules":
-          GetRemoteModules(dispatch, JSON.parse(getState().builder.repo));
+          GetRemoteModules(
+            dispatch,
+            JSON.parse(getState().builder.repo)
+          );
           break;
         case "builder/update-modules-list":
           UpdateModulesList(dispatch);
           break;
         case "builder/import-module":
           ImportModule();
+          break;
+        case "builder/set-settings-visibility":
+          SetSettingsVisibility(
+            dispatch,
+            action.payload,
+          );
+          break;
+        case "builder/toggle-settings-visibility":
+          ToggleSettingsVisibility(
+            dispatch,
+            getState().builder.settings_visible
+          );
           break;
         default:
           break;
@@ -105,6 +130,12 @@ interface IPayloadString {
   type: string;
 }
 type TPayloadString = (action: IPayloadString) => void;
+
+interface IPayloadBool {
+  payload: boolean;
+  type: string;
+}
+type TPayloadBool = (action: IPayloadBool) => void;
 
 const CompileToJSON = async () => {
   const app = BuilderEngine.Instance;
@@ -144,7 +175,8 @@ const CompileToJSON = async () => {
 
 const BuildAndRun = async (
   dispatchString: TPayloadString,
-  snakemake_args: string
+  snakemake_args: string,
+  snakemake_backend: string
 ) => {
   const app = BuilderEngine.Instance;
   const query: Record<string, unknown> = {
@@ -154,6 +186,7 @@ const BuildAndRun = async (
       content: app.GetModuleListJSON(),
       targets: app.GetLeafNodeNames(),
       args: snakemake_args,
+      backend: snakemake_backend,
     },
   };
   const callback = (result) => {
@@ -210,7 +243,8 @@ interface IPayloadLink {
 const AddLink = async (
   action: IPayloadLink,
   auto_validate_connections: boolean,
-  dispatch: TPayloadString
+  snakemake_backend: string,
+  dispatch: TPayloadString,
 ) => {
   // Skip check if auto-validation is disabled
   if (!auto_validate_connections) {
@@ -229,12 +263,13 @@ const AddLink = async (
   const nodename = JSON.parse(node.getOptions().extras)["name"];
 
   // Check node dependencies
-  CheckNodeDependencies(nodename, dispatch);
+  CheckNodeDependencies(nodename, dispatch, snakemake_backend);
 };
 
 const CheckNodeDependencies = async (
   nodename: string,
-  dispatch: TPayloadString
+  dispatch: TPayloadString,
+  snakemake_backend: string
 ) => {
   // Identify all incoming connections to the Target node and build
   //  a JSON Builder object, given it's immediate dependencies
@@ -251,6 +286,7 @@ const CheckNodeDependencies = async (
     data: {
       format: "Snakefile",
       content: JSON.stringify(jsDeps),
+      backend: snakemake_backend,
     },
   };
   // Set node grey to indicate checking
@@ -290,6 +326,7 @@ const CheckNodeDependencies = async (
 const NodeSelected = async (
   action: IPayloadRecord,
   dispatch: TPayloadString,
+  dispatchBool: TPayloadBool,
   getState
 ) => {
   // Deselect any nodes first and wait for the state to update
@@ -299,6 +336,8 @@ const NodeSelected = async (
     };
     await deselect();
   }
+  // Close settings menu (if open)
+  dispatchBool(builderSetSettingsVisibility(false));
   // Select the node
   const builder = BuilderEngine.Instance;
   const id = (action.payload as Record<string, string>).id;
@@ -384,6 +423,7 @@ const GetRemoteModules = async (
 ) => {
   // Get list of remote modules
   dispatchString(builderUpdateStatusText("Loading modules..."));
+  console.log("Repository settings: ", repo);
   const app = BuilderEngine.Instance;
   const query: Record<string, unknown> = {
     query: "builder/get-remote-modules",
@@ -540,3 +580,23 @@ const SubmitQuery = (query: Record<string, unknown>, dispatch, callback) => {
   // Received query request
   if (JSON.stringify(query) !== JSON.stringify({})) postRequest();
 };
+
+const SetSettingsVisibility = (
+  dispatch: TPayloadString,
+  new_state: boolean
+) => {
+  if (new_state)
+    // Close node info pane
+    dispatch(builderNodeDeselected(""));
+  return 0;
+}
+
+const ToggleSettingsVisibility = (
+  dispatch: TPayloadString,
+  settings_visible: boolean
+) => {
+  SetSettingsVisibility(
+    dispatch,
+    !settings_visible
+  );
+}

--- a/nodemapper/src/redux/middleware/builder.ts
+++ b/nodemapper/src/redux/middleware/builder.ts
@@ -39,7 +39,7 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           BuildAndRun(
             dispatch,
             getState().builder.snakemake_args,
-            getState().builder.snakemake_backend,
+            getState().builder.snakemake_backend
           );
           break;
         case "builder/clean-build-folder":
@@ -53,14 +53,14 @@ export const builderMiddleware = ({ getState, dispatch }) => {
             action,
             getState().builder.auto_validate_connections,
             getState().builder.snakemake_backend,
-            dispatch,
+            dispatch
           );
           break;
         case "builder/check-node-dependencies":
           CheckNodeDependencies(
             action.payload,
             dispatch,
-            getState().builder.snakemake_backend,
+            getState().builder.snakemake_backend
           );
           break;
         case "builder/node-selected":
@@ -84,10 +84,7 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           );
           break;
         case "builder/get-remote-modules":
-          GetRemoteModules(
-            dispatch,
-            JSON.parse(getState().builder.repo)
-          );
+          GetRemoteModules(dispatch, JSON.parse(getState().builder.repo));
           break;
         case "builder/update-modules-list":
           UpdateModulesList(dispatch);
@@ -96,10 +93,7 @@ export const builderMiddleware = ({ getState, dispatch }) => {
           ImportModule();
           break;
         case "builder/set-settings-visibility":
-          SetSettingsVisibility(
-            dispatch,
-            action.payload,
-          );
+          SetSettingsVisibility(dispatch, action.payload);
           break;
         case "builder/toggle-settings-visibility":
           ToggleSettingsVisibility(
@@ -244,7 +238,7 @@ const AddLink = async (
   action: IPayloadLink,
   auto_validate_connections: boolean,
   snakemake_backend: string,
-  dispatch: TPayloadString,
+  dispatch: TPayloadString
 ) => {
   // Skip check if auto-validation is disabled
   if (!auto_validate_connections) {
@@ -589,14 +583,11 @@ const SetSettingsVisibility = (
     // Close node info pane
     dispatch(builderNodeDeselected(""));
   return 0;
-}
+};
 
 const ToggleSettingsVisibility = (
   dispatch: TPayloadString,
   settings_visible: boolean
 ) => {
-  SetSettingsVisibility(
-    dispatch,
-    !settings_visible
-  );
-}
+  SetSettingsVisibility(dispatch, !settings_visible);
+};

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -11,23 +11,26 @@ interface IBuilderState {
   terminal_visibile: boolean;
   settings_visible: boolean;
   snakemake_args: string;
+  snakemake_backend: string;
   auto_validate_connections: boolean;
 }
 
 // State
 const builderStateInit: IBuilderState = {
   repo: JSON.stringify({
-    type: "github", // local | github
-    listing_type: "DirectoryListing", // DirectoryListing | BranchListing
-    repo: "kraemer-lab/vneyard", // local path or github repo (user/repo)
+    type: "local", // local | github
+    listing_type: "LocalFilesystem", // LocalFilesystem, // DirectoryListing | BranchListing
+    //repo: "kraemer-lab/vneyard", // local path or github repo (user/repo)
+    repo: "/Users/jsb/repos/jsbrittain/snakeshack",
   }),
   modules_list: "[]",
   statustext: "",
-  nodeinfo: "{}", // {} requires to be a valid JSON string
+  nodeinfo: "{}", // {} required to be a valid JSON string
   can_selected_expand: true,
   terminal_visibile: false,
   settings_visible: false,
-  snakemake_args: "--cores 1 --use-conda $(snakemake --list)",
+  snakemake_args: "--cores 1 --use-conda", // $(snakemake --list)",
+  snakemake_backend: "builtin", // builtin | system
   auto_validate_connections: false,
 };
 
@@ -89,6 +92,10 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
       state.terminal_visibile = true;
       console.info("[Reducer] " + action.type);
     })
+    .addCase(actions.builderSetSettingsVisibility, (state, action) => {
+      state.settings_visible = action.payload;
+      console.info("[Reducer] " + action.type);
+    })
     .addCase(actions.builderToggleSettingsVisibility, (state, action) => {
       state.settings_visible = !state.settings_visible;
       console.info("[Reducer] " + action.type);
@@ -103,6 +110,10 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
     })
     .addCase(actions.builderToggleAutoValidateConnections, (state, action) => {
       state.auto_validate_connections = !state.auto_validate_connections;
+      console.info("[Reducer] " + action.type);
+    })
+    .addCase(actions.builderSelectSnakemakeBackend, (state, action) => {
+      state.snakemake_backend = action.payload;
       console.info("[Reducer] " + action.type);
     });
 });

--- a/runner/runner/__init__.py
+++ b/runner/runner/__init__.py
@@ -7,5 +7,6 @@ from .runner import Launch_cmd  # noqa: F401
 from .runner import Lint  # noqa: F401
 from .runner import LintContents  # noqa: F401
 from .runner import LoadWorkflow  # noqa: F401
+from .runner import SnakemakeRun  # noqa: F401
 from .runner import Tokenize  # noqa: F401
 from .runner import TokenizeFromFile  # noqa: F401

--- a/runner/runner/runner.py
+++ b/runner/runner/runner.py
@@ -105,7 +105,11 @@ def CheckNodeDependencies(data: dict) -> dict:
     """Checks the dependencies of a node, given the node and first-order inputs."""
     if data["format"] == "Snakefile":
         js = json.loads(data["content"])
-        response: dict = snakefile.CheckNodeDependencies(js)
+        snakemake_launcher = data.get("backend", "")
+        response: dict = snakefile.CheckNodeDependencies(
+            js,
+            snakemake_launcher,
+        )
     else:
         raise ValueError(f"Format not supported: {data['format']}")
     return response

--- a/runner/runner/runner.py
+++ b/runner/runner/runner.py
@@ -53,6 +53,7 @@ def Launch_cmd(data: dict, *args, **kwargs) -> dict:
     """Returns the launch command for a workflow"""
     if data["format"] == "Snakefile":
         snakemake_args = data.get("args", "").split(" ")
+        args = *args, *data.get("targets", [])
         cmd, workdir = snakefile.Launch_cmd(
             data["content"],
             *snakemake_args,
@@ -118,10 +119,12 @@ def CheckNodeDependencies(data: dict) -> dict:
 def SnakemakeRun(data: dict) -> dict:
     """Run snakemake using a customised snakemake package import"""
     if data["format"] == "Snakefile":
+        capture_output = data["content"].get("capture_output", False)
         stdout, stderr = snakefile.snakemake_run(
             data["content"]["command"].split(" "),
             data["content"]["workdir"],
-            capture_output=False,
+            capture_output=capture_output,
+            snakemake_launcher=data["content"].get("backend", ""),
         )
         response = {
             "stdout": stdout,

--- a/runner/runner/runner.py
+++ b/runner/runner/runner.py
@@ -109,3 +109,20 @@ def CheckNodeDependencies(data: dict) -> dict:
     else:
         raise ValueError(f"Format not supported: {data['format']}")
     return response
+
+
+def SnakemakeRun(data: dict) -> dict:
+    """Run snakemake using a customised snakemake package import"""
+    if data["format"] == "Snakefile":
+        stdout, stderr = snakefile.snakemake_run(
+            data["content"]["command"].split(" "),
+            data["content"]["workdir"],
+            capture_output=False,
+        )
+        response = {
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+    else:
+        raise ValueError(f"Format not supported: {data['format']}")
+    return response

--- a/runner/runner/snakemake_runner/snakefile.py
+++ b/runner/runner/snakemake_runner/snakefile.py
@@ -1,12 +1,12 @@
-import io
-import os
-import json
-import shutil
-import logging
-import platform
-import tempfile
-import subprocess
 import contextlib
+import io
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
 from contextlib import redirect_stderr
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -46,6 +46,8 @@ logging.info("Working directory: %s", os.getcwd())
 
 # Override snakemake's 'AUTO' protocol mapper (this replaces the normal dynamic
 # import behaviour which is not supported when building PyInstaller binaries)
+
+
 @property  # type: ignore
 def protocol_mapping(self):
     provider_list = [
@@ -418,7 +420,9 @@ def GetMissingFileDependencies_FromContents(
     deps = []
     with IsolatedTempFile(content_str) as snakefile:
         path = os.path.dirname(os.path.abspath(snakefile))
-        while file_list := GetMissingFileDependencies_FromFile(snakefile, snakemake_launcher):
+        while file_list := GetMissingFileDependencies_FromFile(
+            snakefile, snakemake_launcher
+        ):
             deps.extend(file_list)
 
             # Return early if target dependencies are not resolved
@@ -435,8 +439,8 @@ def GetMissingFileDependencies_FromContents(
 
 def GetMissingFileDependencies_FromFile(
     filename: str,
-    snakemake_launcher: str = "",
     *args,
+    snakemake_launcher: str = "",
     **kwargs,
 ) -> List[str]:
     """Get missing file dependencies from snakemake (single file)
@@ -449,8 +453,8 @@ def GetMissingFileDependencies_FromFile(
 
     stdout, stderr = snakemake_launch(
         filename,
-        snakemake_launcher,
         *args,
+        snakemake_launcher=snakemake_launcher,
         **kwargs,
     )
     stderr = "\n".join(stderr.split("\n"))
@@ -459,14 +463,18 @@ def GetMissingFileDependencies_FromFile(
         return []
     if not stderr:
         return []
-    exceptions = set([
-        ex
-        for ex in [line.split(" ")[0] for line in stderr.split("\n")[0:2]]
-        if ex.endswith("Exception")
-    ])
-    permitted_exceptions = set([
-        "MissingInputException",
-    ])
+    exceptions = set(
+        [
+            ex
+            for ex in [line.split(" ")[0] for line in stderr.split("\n")[0:2]]
+            if ex.endswith("Exception")
+        ]
+    )
+    permitted_exceptions = set(
+        [
+            "MissingInputException",
+        ]
+    )
     if len(exceptions - permitted_exceptions) > 0:
         raise Exception(
             f"A non-expected error has been detected: \nstdout={stdout}\nstderr={stderr}"
@@ -611,8 +619,8 @@ def snakemake_run(
 
 def snakemake_launch(
     filename: str,
-    snakemake_launcher: str = "",
     *args,
+    snakemake_launcher: str = "",
     **kwargs,
 ) -> Tuple[str, str]:
     """Construct the snakemake command and then launch


### PR DESCRIPTION
- [X] Ensure build files do not use relative paths (which are unknown when launching in app mode)
- [X] Add log files and output to a common folder (users home folder)
- [X] Add snakemake backend selection [built-in / system]
- [X] Implement switching mechanism to launch selected Snakemake backend [built-in / system]
- [X] Provide target rule list to snakemake (`_target` rule of module, if it exists, all rules in module otherwise [for leaf nodes only])
- [X] Read build.zip file target from python; delete old zip file+folder in python