### PR TITLE
Add macos-14 (M1) runners to github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: install MacOS (M1) build dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ] && [ "$RUNNER_ARCH" == "ARM64" ]; then
+            brew install pango
+          fi
       - name: build
         working-directory: ./electron-app
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-12 provides Intel builds, macos-14 provides M1 builds
+        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/postbuildchecks.yml
+++ b/.github/workflows/postbuildchecks.yml
@@ -32,6 +32,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: install MacOS (M1) build dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ] && [ "$RUNNER_ARCH" == "ARM64" ]; then
+            brew install pango
+          fi
       - name: build
         working-directory: ./electron-app
         shell: bash
@@ -42,10 +48,10 @@ jobs:
           yarn
           yarn build
           yarn package
-      - name: install docker (MacOS)
+      - name: install docker MacOS (Intel chips)
         shell: bash
         run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
+          if [ "$RUNNER_OS" == "macOS" ] && [ "$RUNNER_ARCH" == "X64" ]; then
             brew install docker
             colima start
           fi

--- a/.github/workflows/postbuildchecks.yml
+++ b/.github/workflows/postbuildchecks.yml
@@ -17,7 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-12 provides Intel builds, macos-14 provides M1 builds
+        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: install MacOS (M1) build dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ] && [ "$RUNNER_ARCH" == "ARM64" ]; then
+            brew install pango
+          fi
       - name: build
         working-directory: ./electron-app
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-12 provides Intel builds, macos-14 provides M1 builds
+        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add Apple M1 builds to github actions.

Resolves #74 