### PR TITLE
Package workflow

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ boto3==1.28.19
 botocore==1.31.19
 ../builder
 certifi==2023.7.22
+cachetools==5.3.2
 charset-normalizer==3.1.0
 click==8.1.3
 ConfigArgParse==1.5.3

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,4 +1,5 @@
 .
+cachetools==5.3.2
 certifi==2023.7.22
 charset-normalizer==3.1.0
 idna==3.4

--- a/electron-app/postbuild_tests/modules.test.ts
+++ b/electron-app/postbuild_tests/modules.test.ts
@@ -9,11 +9,12 @@ import * as webdriver from "selenium-webdriver";
 
 import { runif } from "./utils";
 import { is_windows } from "./utils";
-import { is_installed } from "./utils";
 import { dragAndDrop } from "./utils";
+import { is_installed } from "./utils";
 import { FlushConsoleLog } from "./utils";
-import { RedirectConsoleLog } from "./utils";
+import { SetCheckBoxByID } from "./utils";
 import { WaitForReturnCode } from "./utils";
+import { RedirectConsoleLog } from "./utils";
 import { EasyEdit_SetFieldByKey } from "./utils";
 import { BuildAndRun_SingleModuleWorkflow } from "./utils";
 import { BuildAndRun_MultiModuleWorkflow } from "./utils";
@@ -108,6 +109,11 @@ describe("modules", () => {
     await driver
       .findElement(By.id("buttonBuilderSettingsRepositoryListAddItem"))
       .click();
+
+    // Ensure that interface options are set as expected
+    await SetCheckBoxByID(driver, "display_module_settings", false);
+    await SetCheckBoxByID(driver, "auto_validate_connections", false);
+    await SetCheckBoxByID(driver, "package_modules_in_workflow", false);
 
     // Close settings pane
     await driver.findElement(By.id("btnSidenavBuilder")).click();

--- a/electron-app/postbuild_tests/utils.ts
+++ b/electron-app/postbuild_tests/utils.ts
@@ -238,6 +238,25 @@ const EasyEdit_SetFieldByValue = async (
     .sendKeys(s);
 };
 
+const SetCheckBox = async (
+  checkbox: webdriver.WebElement,
+  checked: boolean
+) => {
+  // Set checkbox to checked or unchecked
+  const is_checked = await checkbox.isSelected();
+  if (is_checked != checked) await checkbox.click();
+};
+
+const SetCheckBoxByID = async (
+  driver: webdriver.ThenableWebDriver,
+  id: string,
+  checked: boolean
+) => {
+  // Set checkbox to checked or unchecked
+  const checkbox = await driver.findElement(By.id(id));
+  await SetCheckBox(checkbox, checked);
+};
+
 const BuildAndRun_SingleModuleWorkflow = async (
   driver: webdriver.ThenableWebDriver,
   modulename: string,
@@ -432,6 +451,7 @@ export {
   RedirectConsoleLog,
   FlushConsoleLog,
   WaitForReturnCode,
+  SetCheckBoxByID,
   EasyEdit_SetFieldByKey,
   EasyEdit_SetFieldByValue,
   BuildAndRun_SingleModuleWorkflow,

--- a/electron-app/postbuild_tests/utils.ts
+++ b/electron-app/postbuild_tests/utils.ts
@@ -362,9 +362,6 @@ const Build_RunWithDocker_SingleModuleWorkflow = async (
   //
   // This was a workaround as local modules could not be run through containers until
   // workflow packaging was introduced.
-  console.log("Open the module in the editor and Expand");
-  console.log("modulename: ", modulename);
-  console.log("expand_module: ", expand_module);
   if (expand_module) {
     // Click on the canvas module element. This actually finds both the repository entry
     // and the canvas element, so we click on both as we cannot guarantee ordering.

--- a/electron-app/src/main.ts
+++ b/electron-app/src/main.ts
@@ -17,13 +17,13 @@ const createWindow = () => {
       preload: path.join(__dirname, "preload.js"),
     },
   });
-
   if (app.isPackaged) {
     win.loadFile("index.html"); //prod
   } else {
     win.loadURL("http://localhost:5001"); //dev
   }
 
+  // Command line arguments
   const downloadpath = app.commandLine.getSwitchValue("downloadpath");
   if (downloadpath) {
     const ses = win.webContents.session;

--- a/electron-app/src/python/pyrunner.py
+++ b/electron-app/src/python/pyrunner.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 from zipfile import ZipFile
 from zipfile import ZipInfo
+from typing import List
 
 import filesystem
 import snakemake
@@ -50,6 +51,7 @@ def BuildAndRun(
         build_path=build_path,
         clean_build=clean_build,  # clean build folder before build
         create_zip=create_zip,  # create zip file
+        package_modules=data.get("package_modules", False),  # package modules
     )
     targets = data.get("targets", [])
     target_modules = m.LookupRuleNames(targets)
@@ -79,7 +81,7 @@ def BuildAndRun(
             },
         }
     )
-    snakemake_list = response["stdout"].split("\n")
+    snakemake_list: List[str] = list(filter(None, response["stdout"].split("\n")))
     logging.debug("snakemake --list output: %s", snakemake_list)
     target_rules = []
     for target in target_modules:

--- a/electron-app/src/python/pyrunner.py
+++ b/electron-app/src/python/pyrunner.py
@@ -4,9 +4,9 @@ import logging
 import os
 import sys
 import tempfile
+from typing import List
 from zipfile import ZipFile
 from zipfile import ZipInfo
-from typing import List
 
 import filesystem
 import snakemake
@@ -83,6 +83,7 @@ def BuildAndRun(
     )
     snakemake_list: List[str] = list(filter(None, response["stdout"].split("\n")))
     logging.debug("snakemake --list output: %s", snakemake_list)
+    logging.debug(f"target_modules: {target_modules}")
     target_rules = []
     for target in target_modules:
         if not target:

--- a/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
+++ b/nodemapper/src/gui/Builder/components/BuilderSettings.tsx
@@ -10,6 +10,7 @@ import { builderSetEnvironmentVars } from "redux/actions";
 import { builderSelectSnakemakeBackend } from "redux/actions";
 import { builderSetDisplayModuleSettings } from "redux/actions";
 import { builderSetAutoValidateConnections } from "redux/actions";
+import { builderSetPackageModulesInWorkflow } from "redux/actions";
 
 const default_input_size = 35;
 const panel_background_color = "#2e3746";
@@ -43,6 +44,9 @@ const BuilderSettings = () => {
   const auto_validate_connections = useAppSelector(
     (state) => state.builder.auto_validate_connections
   );
+  const package_modules_in_workflow = useAppSelector(
+    (state) => state.builder.package_modules_in_workflow
+  );
 
   const SetSnakemakeArgs = (args: string) =>
     dispatch(builderSetSnakemakeArgs(args));
@@ -58,6 +62,9 @@ const BuilderSettings = () => {
 
   const SetAutoValidateConnections = (value: boolean) =>
     dispatch(builderSetAutoValidateConnections(value));
+
+  const SetPackageModulesInWorkflow = (value: boolean) =>
+    dispatch(builderSetPackageModulesInWorkflow(value));
 
   return (
     <>
@@ -173,6 +180,20 @@ const BuilderSettings = () => {
                 <label htmlFor="auto_validate_connections">
                   {" "}
                   Auto-validate connections
+                </label>
+              </p>
+              <p>
+                <input
+                  type="checkbox"
+                  id="package_modules_in_workflow"
+                  checked={package_modules_in_workflow}
+                  onChange={(e) =>
+                    SetPackageModulesInWorkflow(e.target.checked)
+                  }
+                />
+                <label htmlFor="package_modules_in_workflow">
+                  {" "}
+                  Package all modules in workflow
                 </label>
               </p>
             </div>

--- a/nodemapper/src/redux/actions/builder.ts
+++ b/nodemapper/src/redux/actions/builder.ts
@@ -17,6 +17,9 @@ export const builderSetAutoValidateConnections = createAction<boolean>(
 export const builderToggleAutoValidateConnections = createAction(
   "builder/toggle-auto-validate-connections"
 );
+export const builderSetPackageModulesInWorkflow = createAction<boolean>(
+  "builder/set-package-modules-in-workflow"
+);
 
 export const builderBuildAsModule = createAction("builder/build-as-module");
 export const builderBuildAsWorkflow = createAction("builder/build-as-workflow");

--- a/nodemapper/src/redux/middleware/builder.ts
+++ b/nodemapper/src/redux/middleware/builder.ts
@@ -45,6 +45,7 @@ export const builderMiddleware = ({ getState, dispatch }) => {
             getState().builder.snakemake_backend,
             getState().builder.conda_backend,
             getState().builder.environment_variables,
+            false, // package_modules (workflow only)
             getState().builder.nodes,
             getState().builder.edges
           );
@@ -59,6 +60,7 @@ export const builderMiddleware = ({ getState, dispatch }) => {
             getState().builder.snakemake_backend,
             getState().builder.conda_backend,
             getState().builder.environment_variables,
+            getState().builder.package_modules_in_workflow,
             getState().builder.nodes,
             getState().builder.edges
           );
@@ -184,6 +186,7 @@ const BuildAs = async (
   snakemake_backend: string,
   conda_backend: string,
   environment_variables: string,
+  package_modules: boolean,
   nodes: Node[],
   edges: Edge[]
 ) => {
@@ -199,6 +202,7 @@ const BuildAs = async (
       backend: snakemake_backend,
       conda_backend: conda_backend,
       environment_variables: environment_variables,
+      package_modules: package_modules,
     },
   };
   const callback = (result) => {
@@ -507,6 +511,7 @@ const WriteStoreConfig = async (state) => {
     environment_variables: state.environment_variables,
     display_module_settings: state.display_module_settings,
     auto_validate_connections: state.auto_validate_connections,
+    package_modules_in_workflow: state.package_modules_in_workflow,
   });
 };
 

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -40,6 +40,7 @@ export interface IBuilderState {
   environment_variables: string;
   display_module_settings: boolean;
   auto_validate_connections: boolean;
+  package_modules_in_workflow: boolean;
 }
 
 // Defaults
@@ -77,6 +78,7 @@ const builderStateInit: IBuilderState = {
   environment_variables: "",
   display_module_settings: false,
   auto_validate_connections: false,
+  package_modules_in_workflow: false,
 };
 
 // Nodemap
@@ -170,6 +172,10 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
     })
     .addCase(actions.builderToggleAutoValidateConnections, (state, action) => {
       state.auto_validate_connections = !state.auto_validate_connections;
+      console.info("[Reducer] " + action.type);
+    })
+    .addCase(actions.builderSetPackageModulesInWorkflow, (state, action) => {
+      state.package_modules_in_workflow = action.payload;
       console.info("[Reducer] " + action.type);
     })
     .addCase(actions.builderSelectSnakemakeBackend, (state, action) => {


### PR DESCRIPTION
Enable packaging of workflows. This stores all modules within the zip archieve (and thus the container when expanded), so that no external loading is required (apart from initial container creation due to `conda`, and any explicit references to external files within the workflows).