### PR TITLE
Include Python std libs in environment distributed with GRAPEVNE

### DIFF
--- a/electron-app/build_deps.sh
+++ b/electron-app/build_deps.sh
@@ -31,6 +31,7 @@ python -m PyInstaller src/python/pyrunner.py \
     --hidden-import smart_open.s3 \
     --hidden-import smart_open.ssh \
     --hidden-import smart_open.webhdfs \
+    $(python collect_stdlibs.py) \
     --add-data "src/python/Dockerfile:." \
     --add-data "src/python/build_container_sh:." \
     --add-data "src/python/launch_container_sh:."

--- a/electron-app/collect_stdlibs.py
+++ b/electron-app/collect_stdlibs.py
@@ -1,0 +1,9 @@
+import sys
+
+reject_list = [
+    'antigravity'
+]
+
+modules = set(sys.stdlib_module_names) - set(reject_list)
+
+print('\n'.join([f'   --collect-all {m}' for m in modules]))


### PR DESCRIPTION
Include Python std libs in environment distributed with GRAPEVNE (permits access in Snakefiles run through GUI)