### PR TITLE
Fix: inputbox looses focus during edits

### DIFF
--- a/nodemapper/src/gui/Builder/components/NodeInfo/EditBox.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/EditBox.tsx
@@ -94,6 +94,7 @@ export const EditBoxText = (userprops: IEditBoxText) => {
           onBlur();
         }
       }}
+      onKeyDown={e => e.stopPropagation()}  // prevent letter search-select in TreeView
       onBlur={onBlur}
       inputProps={{
         className: useStyle(valueType),


### PR DESCRIPTION
Since the upgrade to SimpleTreeView the input text fields have been loosing focus due to the letter search-select features of the parent tree. We provide a fix for this by preventing the keydown event from propagating to the parent level from the input text field.