### PR TITLE
Add file picker for parameters of type 'file'

### DIFF
--- a/electron-app/src/api.ts
+++ b/electron-app/src/api.ts
@@ -11,6 +11,7 @@ export type DisplayAPI = {
   StoreReadConfig: () => Promise<Query>;
   StoreWriteConfig: (query: Query) => Promise<Query>;
   SelectFolder: (path: string) => Promise<string[]>;
+  SelectFile: (path: string) => Promise<string[]>;
 };
 
 export type BuilderAPI = {

--- a/electron-app/src/handles.ts
+++ b/electron-app/src/handles.ts
@@ -84,6 +84,14 @@ export async function display_SelectFolder(event: Event, path: string, win: Elec
   return result.filePaths;
 }
 
+export async function display_SelectFile(event: Event, path: string, win: Electron.BrowserWindow) {
+  const result = await dialog.showOpenDialog(win, {
+    defaultPath: path,
+    properties: ['openFile'],
+  });
+  return result.filePaths;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Builder query handlers
 ///////////////////////////////////////////////////////////////////////////////

--- a/electron-app/src/main.ts
+++ b/electron-app/src/main.ts
@@ -115,6 +115,9 @@ app.whenReady().then(() => {
   ipcMain.handle('display/select-folder', (event: Event, path: string) =>
     handles.display_SelectFolder(event, path, win),
   );
+  ipcMain.handle('display/select-file', (event: Event, path: string) =>
+    handles.display_SelectFile(event, path, win),
+  );
 
   // Builder
   ipcMain.handle('builder/get-remote-modules', handles.builder_GetRemoteModules);

--- a/electron-app/src/preload.ts
+++ b/electron-app/src/preload.ts
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('displayAPI', {
   StoreReadConfig: () => ipcRenderer.invoke('display/store-read-config'),
   StoreWriteConfig: (query: Query) => ipcRenderer.invoke('display/store-write-config', query),
   SelectFolder: (path: string) => ipcRenderer.invoke('display/select-folder', path),
+  SelectFile: (path: string) => ipcRenderer.invoke('display/select-file', path),
 });
 
 contextBridge.exposeInMainWorld('builderAPI', {

--- a/nodemapper/src/api.ts
+++ b/nodemapper/src/api.ts
@@ -11,6 +11,7 @@ export type DisplayAPI = {
   StoreReadConfig: () => Promise<Query>;
   StoreWriteConfig: (query: Query) => Promise<Query>;
   SelectFolder: (path: string) => Promise<string[]>;
+  SelectFile: (path: string) => Promise<string[]>;
 };
 
 export type BuilderAPI = {

--- a/nodemapper/src/gui/Builder/components/NodeInfo/ParameterList.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/ParameterList.tsx
@@ -14,8 +14,8 @@ import {
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { styled } from '@mui/material/styles';
-import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -337,7 +337,9 @@ export default function ParameterList({
             gap: '3px',
           }}
         >
-          <SimpleTreeView defaultExpandedItems={Array.from({ length: 999 }, (_, i) => i.toString())}>
+          <SimpleTreeView
+            defaultExpandedItems={Array.from({ length: 999 }, (_, i) => i.toString())}
+          >
             <NodeParameters node={node} keylist={[]} />
           </SimpleTreeView>
         </Box>

--- a/nodemapper/src/gui/Settings/RepoOptions.tsx
+++ b/nodemapper/src/gui/Settings/RepoOptions.tsx
@@ -7,14 +7,14 @@ import { getMasterRepoListURL } from 'redux/globals';
 import { IRepo } from 'redux/reducers/builder';
 import { useAppDispatch, useAppSelector } from 'redux/store/hooks';
 
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 
 const displayAPI = window.displayAPI;
 
@@ -251,13 +251,11 @@ const RepoOptions: React.FC<{ labelWidth: string }> = ({ labelWidth }) => {
           />
           {displayFolderSelect && (
             <IconButton
-              onClick = {() => {
-                displayAPI.SelectFolder(repoURL)
-                  .then((folderPaths) => {
-                    setRepoURL(folderPaths[0]);
-                  })
-                }
-              }
+              onClick={() => {
+                displayAPI.SelectFolder(repoURL).then((folderPaths) => {
+                  setRepoURL(folderPaths[0]);
+                });
+              }}
             >
               <FolderOutlinedIcon />
             </IconButton>


### PR DESCRIPTION
Add file selection dialog, enabled by setting the parameter metadata type to 'file' in the config.yaml file, e.g.
```yaml
params:
  SomeFilename:
    Filename: "data.csv"
    Folder: "/data"
  ":SomeFilename":
    type: "File"
```

This follows the parameters metadata scheme discussed in #174 and implemented in #203 .

If a 'file' type parameter is detected, GRAPEVNE offers a file picker option in the parameters interface:
<img width="1022" alt="Screenshot 2024-06-28 at 11 56 21" src="https://github.com/kraemer-lab/GRAPEVNE/assets/98161205/ba059e8d-2c33-4dde-ae37-659e2cc960f3">

When linking downstream modules, this arrangement allows the separation of 'filename' and 'folder' so that the filename can be linked and propagated to subsequent modules:
<img width="294" alt="Screenshot 2024-06-28 at 11 56 36" src="https://github.com/kraemer-lab/GRAPEVNE/assets/98161205/3783d36d-f808-442d-9d9b-8b6d00656a42">
As this is a configuration parameter this separation is also accessible in the Snakefile's.

This functionality is currently enabled and can be tested with the `LinkLocalFile` module (https://github.com/kraemer-lab/vneyard/pull/21)