### PR TITLE
Workflow alerts

### DIFF
--- a/builder/builder/builder.py
+++ b/builder/builder/builder.py
@@ -13,11 +13,13 @@ from typing import Optional
 from typing import Tuple
 from typing import TypedDict
 from typing import Union
-from .workflow_alerts import WorkflowAlerts, ProcessWorkflowAlerts
 
 import cachetools
 import requests
 import yaml
+
+from .workflow_alerts import ProcessWorkflowAlerts
+from .workflow_alerts import WorkflowAlerts
 
 
 Namespace = Union[str, None, dict]
@@ -231,34 +233,34 @@ class Model:
             recipients,
         ) -> str:
             s = "\n"
-            s += f'{directive}:\n'
-            s += '    try:\n'  # don't fail the run because of the workflow alert
-            s += '        import sendmail\n'
-            s += '        sendmail.send_email(\n'
+            s += f"{directive}:\n"
+            s += "    try:\n"  # don't fail the run because of the workflow alert
+            s += "        import sendmail\n"
+            s += "        sendmail.send_email(\n"
             s += f'            server_address="{smtp_address}",\n'
             s += f'            server_port="{smtp_port}",\n'
             s += f'            subject="{subject}",\n'
             s += f'            body="{body}",\n'
-            s += f'            sender={sender},\n'  # don't quote (see below)
+            s += f"            sender={sender},\n"  # don't quote (see below)
             s += f'            recipients="{recipients}",\n'
-            s += f'            username={username},\n'  # don't quote as can be used to
-            s += f'            password={password},\n'  # get environment variables
-            s += '        )\n'
-            s += '    except Exception as e:\n'
+            s += f"            username={username},\n"  # don't quote as can be used to
+            s += f"            password={password},\n"  # get environment variables
+            s += "        )\n"
+            s += "    except Exception as e:\n"
             s += '        print("Error sending email: ", e)\n'
             return s
 
         s = ""
         if self.alerts.onsuccess:
             s += create_alert(
-                'onsuccess',
+                "onsuccess",
                 self.alerts.onsuccess.subject,
                 self.alerts.onsuccess.body,
                 self.alerts.onsuccess.recipients,
             )
         if self.alerts.onerror:
             s += create_alert(
-                'onerror',
+                "onerror",
                 self.alerts.onerror.subject,
                 self.alerts.onerror.body,
                 self.alerts.onerror.recipients,

--- a/builder/builder/sendmail.py
+++ b/builder/builder/sendmail.py
@@ -1,13 +1,13 @@
-import os
-import json
-import smtplib
-import logging
 import argparse
-from email.utils import formatdate
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-from email.mime.base import MIMEBase
+import json
+import logging
+import os
+import smtplib
 from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
 
 # SMTP username and password can be provided as environment variables (but can be
 # overriden by a credentials file if one is specified)

--- a/builder/builder/sendmail.py
+++ b/builder/builder/sendmail.py
@@ -1,0 +1,93 @@
+import os
+import json
+import smtplib
+import logging
+import argparse
+from email.utils import formatdate
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email import encoders
+
+# SMTP username and password can be provided as environment variables (but can be
+# overriden by a credentials file if one is specified)
+EMAIL_USERNAME = os.environ.get("EMAIL_USERNAME", "")
+EMAIL_PASSWORD = os.environ.get("EMAIL_PASSWORD", "")
+
+
+def send_email(
+    server_address: str,
+    server_port: int,
+    subject: str,
+    body: str,
+    sender: str,
+    recipients: str | list[str],
+    username: str,
+    password: str,
+    files: list[str] = [],
+):
+    if not (subject and body and sender and recipients and password):
+        raise ValueError(
+            "All parameters (except 'files') must be provided and non-empty"
+        )
+
+    # Header and body
+    msg = MIMEMultipart()
+    msg["From"] = sender
+    msg["To"] = ", ".join(recipients) if isinstance(recipients, list) else recipients
+    msg["Date"] = formatdate(localtime=True)
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body))
+
+    # Attachments
+    for path in files:
+        part = MIMEBase("application", "octet-stream")
+        with open(path, "rb") as file:
+            part.set_payload(file.read())
+        encoders.encode_base64(part)
+        part.add_header(
+            "Content-Disposition",
+            f"attachment; filename={os.path.basename(path)}",
+        )
+        msg.attach(part)
+
+    # Send the email
+    with smtplib.SMTP(server_address, server_port) as server:
+        server.starttls()
+        server.login(username, password)
+        server.sendmail(username, recipients, msg.as_string())
+    logging.info("Message sent.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Send an email")
+    parser.add_argument(
+        "--credentials-file", type=str, help="The file containing the email credentials"
+    )
+    parser.add_argument(
+        "--smtp-server", type=str, help="The address of the SMTP server"
+    )
+    parser.add_argument("--smtp-port", type=int, help="The port of the SMTP server")
+    parser.add_argument("--subject", type=str, help="The subject of the email")
+    parser.add_argument("--body", type=str, help="The body of the email")
+    parser.add_argument(
+        "--recipients", type=str, help="A comma separated list of recipients"
+    )
+    args = parser.parse_args()
+    recipients = args.recipients.split(",")
+    if args.credentials_file:
+        with open(args.credentials_file) as f:
+            credentials = json.load(f)
+            EMAIL_USERNAME = credentials.get("username", "")
+            EMAIL_PASSWORD = credentials.get("password", "")
+    sender = EMAIL_USERNAME
+    send_email(
+        args.smtp_server,
+        args.smtp_port,
+        args.subject,
+        args.body,
+        sender,
+        recipients,
+        EMAIL_USERNAME,
+        EMAIL_PASSWORD,
+    )

--- a/builder/builder/workflow_alerts.py
+++ b/builder/builder/workflow_alerts.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 @dataclass
 class EmailSettings:
     """EmailSettings class for the WorkflowAlert"""
+
     smtp_address: str = ""
     smtp_port: int = 0
     sender: str = ""
@@ -14,6 +15,7 @@ class EmailSettings:
 @dataclass
 class Message:
     """Message class for the WorkflowAlert"""
+
     subject: str = ""
     body: str = ""
     recipients: str = ""
@@ -22,6 +24,7 @@ class Message:
 @dataclass
 class WorkflowAlerts:
     """Initialise the WorkflowAlert"""
+
     email_settings = EmailSettings()
     onsuccess = Message()
     onerror = Message()

--- a/builder/builder/workflow_alerts.py
+++ b/builder/builder/workflow_alerts.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EmailSettings:
+    """EmailSettings class for the WorkflowAlert"""
+    smtp_address: str = ""
+    smtp_port: int = 0
+    sender: str = ""
+    username: str = ""
+    password: str = ""
+
+
+@dataclass
+class Message:
+    """Message class for the WorkflowAlert"""
+    subject: str = ""
+    body: str = ""
+    recipients: str = ""
+
+
+@dataclass
+class WorkflowAlerts:
+    """Initialise the WorkflowAlert"""
+    email_settings = EmailSettings()
+    onsuccess = Message()
+    onerror = Message()
+
+
+def ProcessWorkflowAlerts(config: dict) -> WorkflowAlerts:
+    alert = WorkflowAlerts()
+
+    # Email settings
+    email_settings = config.get("email_settings", {})
+    alert.email_settings.smtp_address = email_settings.get("smtp_server", "")
+    alert.email_settings.smtp_port = email_settings.get("smtp_port", 0)
+    alert.email_settings.sender = email_settings.get("sender", "")
+    alert.email_settings.username = email_settings.get("username", "")
+    alert.email_settings.password = email_settings.get("password", "")
+
+    # On success
+    onsuccess = config.get("onsuccess", {})
+    if onsuccess:
+        message = onsuccess.get("message", {})
+        alert.onsuccess.subject = message.get("subject", "")
+        alert.onsuccess.body = message.get("body", "")
+        alert.onsuccess.recipients = message.get("recipients", "")
+
+    # On Error
+    onerror = config.get("onerror", {})
+    if onerror:
+        message = onerror.get("message", {})
+        alert.onerror.subject = message.get("subject", "")
+        alert.onerror.body = message.get("body", "")
+        alert.onerror.recipients = message.get("recipients", "")
+
+    return alert

--- a/electron-app/build_deps.sh
+++ b/electron-app/build_deps.sh
@@ -32,6 +32,7 @@ python -m PyInstaller src/python/pyrunner.py \
     --hidden-import smart_open.ssh \
     --hidden-import smart_open.webhdfs \
     $(python collect_stdlibs.py) \
+    --add-data "../builder/builder/sendmail.py:./builder/" \
     --add-data "src/python/Dockerfile:." \
     --add-data "src/python/build_container_sh:." \
     --add-data "src/python/launch_container_sh:."

--- a/electron-app/src/python/pyrunner.py
+++ b/electron-app/src/python/pyrunner.py
@@ -102,7 +102,11 @@ def BuildAndRun(
         # Add the first rule to appear in the list (mimics snakemake behaviour)
         try:
             target_rules.append(
-                next(rulename for rulename in snakemake_list if rulename.startswith(target))
+                next(
+                    rulename
+                    for rulename in snakemake_list
+                    if rulename.startswith(target)
+                )
             )
         except StopIteration:
             raise ValueError(f"Cannot determine target rule for module: {target}")

--- a/nodemapper/src/gui/Builder/components/NodeInfo/EditBox.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/EditBox.tsx
@@ -94,7 +94,7 @@ export const EditBoxText = (userprops: IEditBoxText) => {
           onBlur();
         }
       }}
-      onKeyDown={e => e.stopPropagation()}  // prevent letter search-select in TreeView
+      onKeyDown={(e) => e.stopPropagation()} // prevent letter search-select in TreeView
       onBlur={onBlur}
       inputProps={{
         className: useStyle(valueType),

--- a/nodemapper/src/gui/Builder/components/NodeInfo/ParameterList.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/ParameterList.tsx
@@ -14,8 +14,8 @@ import {
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { styled } from '@mui/material/styles';
-import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -337,7 +337,9 @@ export default function ParameterList({
             gap: '3px',
           }}
         >
-          <SimpleTreeView defaultExpandedItems={Array.from({ length: 999 }, (_, i) => i.toString())}>
+          <SimpleTreeView
+            defaultExpandedItems={Array.from({ length: 999 }, (_, i) => i.toString())}
+          >
             <NodeParameters node={node} keylist={[]} />
           </SimpleTreeView>
         </Box>

--- a/nodemapper/src/gui/Settings/RepoOptions.tsx
+++ b/nodemapper/src/gui/Settings/RepoOptions.tsx
@@ -7,14 +7,14 @@ import { getMasterRepoListURL } from 'redux/globals';
 import { IRepo } from 'redux/reducers/builder';
 import { useAppDispatch, useAppSelector } from 'redux/store/hooks';
 
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 
 const displayAPI = window.displayAPI;
 
@@ -251,13 +251,11 @@ const RepoOptions: React.FC<{ labelWidth: string }> = ({ labelWidth }) => {
           />
           {displayFolderSelect && (
             <IconButton
-              onClick = {() => {
-                displayAPI.SelectFolder(repoURL)
-                  .then((folderPaths) => {
-                    setRepoURL(folderPaths[0]);
-                  })
-                }
-              }
+              onClick={() => {
+                displayAPI.SelectFolder(repoURL).then((folderPaths) => {
+                  setRepoURL(folderPaths[0]);
+                });
+              }}
             >
               <FolderOutlinedIcon />
             </IconButton>

--- a/nodemapper/src/gui/Settings/Settings.tsx
+++ b/nodemapper/src/gui/Settings/Settings.tsx
@@ -14,6 +14,7 @@ import DarkModeOption from './DarkModeOption';
 import EnvironmentOptions from './EnvironmentOptions';
 import InterfaceOptions from './InterfaceOptions';
 import SnakemakeOptions from './SnakemakeOptions';
+import WorkflowAlerts from './WorkflowAlerts';
 
 const OptionsPanel = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
@@ -77,6 +78,11 @@ const Settings = () => {
         <Grid item xs={8}>
           <OptionsPanel>
             <InterfaceOptions />
+          </OptionsPanel>
+        </Grid>
+        <Grid item xs={8}>
+          <OptionsPanel>
+            <WorkflowAlerts labelWidth="25%" />
           </OptionsPanel>
         </Grid>
       </Grid>

--- a/nodemapper/src/gui/Settings/WorkflowAlerts.tsx
+++ b/nodemapper/src/gui/Settings/WorkflowAlerts.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { useAppDispatch, useAppSelector } from 'redux/store/hooks';
+import {
+  builderToggleWorkflowAlertOnSuccessEnabled,
+  builderToggleWorkflowAlertOnErrorEnabled,
+  builderSetWorkflowAlertsEmailSMTPServer,
+  builderSetWorkflowAlertsEmailSMTPPort,
+  builderSetWorkflowAlertsEmailUsername,
+  builderSetWorkflowAlertsEmailPassword,
+  builderSetWorkflowAlertsOnSuccessSubject,
+  builderSetWorkflowAlertsOnSuccessBody,
+  builderSetWorkflowAlertsOnErrorSubject,
+  builderSetWorkflowAlertsOnErrorBody,
+} from 'redux/actions';
+import { useTheme } from '@mui/material/styles';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+
+interface IInputItem {
+  id: string;
+  type?: string;
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  labelWidth: string;
+}
+
+const InputItem = ({id, type, label, value, onChange, labelWidth}: IInputItem) => {
+  if (type === undefined) {
+    type = 'text';
+  }
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: '10px',
+        flexDirection: 'row',
+      }}
+    >
+      <Box
+        sx={{
+          width: labelWidth,
+          textAlign: 'right',
+          alignSelf: 'center',
+        }}
+      >
+        <Typography variant="body1">{label}</Typography>
+      </Box>
+      <TextField
+        id={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        style={{ width: '100%' }}
+        size="small"
+      />
+    </Box>
+  )
+} 
+
+interface IEmailSettings {
+  labelWidth: string;
+}
+
+const EmailSettings = ({labelWidth}: IEmailSettings) => {
+  const dispatch = useAppDispatch();
+  const email_settings = useAppSelector(
+    (state) => state.builder.workflow_alerts.email_settings,
+  );
+  const setSMTPServer = (value: string) => dispatch(builderSetWorkflowAlertsEmailSMTPServer(value));
+  const setSMTPPort = (value: string) => {
+    if (isNaN(parseInt(value))) {
+      alert('Port must be a number');
+      return;
+    }
+    dispatch(builderSetWorkflowAlertsEmailSMTPPort(value));
+  };
+  const setUsername = (value: string) => dispatch(builderSetWorkflowAlertsEmailUsername(value));
+  const setPassword = (value: string) => dispatch(builderSetWorkflowAlertsEmailPassword(value));
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+      }}
+    >
+      <InputItem
+        id="settings_workflow_alerts_email_smtp_server"
+        label="SMTP Server:"
+        value={email_settings.smtp_server}
+        onChange={(e) => setSMTPServer(e.target.value)}
+        labelWidth={labelWidth}
+      />
+      <InputItem
+        id="settings_workflow_alerts_email_smtp_port"
+        label="SMTP Port:"
+        value={email_settings.smtp_port.toString()}
+        onChange={(e) => setSMTPPort(e.target.value)}
+        labelWidth={labelWidth}
+      />
+      <InputItem
+        id="settings_workflow_alerts_email_username"
+        label="Username:"
+        value={email_settings.username}
+        onChange={(e) => setUsername(e.target.value)}
+        labelWidth={labelWidth}
+      />
+      <InputItem
+        id="settings_workflow_alerts_email_password"
+        type="password"
+        label="Password:"
+        value={email_settings.password}
+        onChange={(e) => setPassword(e.target.value)}
+        labelWidth={labelWidth}
+      />
+    </Box>
+  )
+}
+
+interface IWorkflowAlertSettings {
+  labelWidth: string;
+  alert_type: string;
+  setSubject: (value: string) => void;
+  setBody: (value: string) => void;
+}
+
+const WorkflowAlertSettings = ({labelWidth, alert_type, setSubject, setBody}: IWorkflowAlertSettings) => {
+  const message = useAppSelector(
+    (state) => state.builder.workflow_alerts[alert_type].message,
+  );
+  
+  return (
+    <Box
+      sx={{
+        width: '100%',
+      }}
+    >
+      <InputItem
+        id="settings_workflow_alerts_email_subject"
+        label="Subject:"
+        value={message.subject}
+        onChange={(e) => setSubject(e.target.value)}
+        labelWidth={labelWidth}
+      />
+      <InputItem
+        id="settings_workflow_alerts_email_message"
+        label="Message:"
+        value={message.body}
+        onChange={(e) => setBody(e.target.value)}
+        labelWidth={labelWidth}
+      />
+    </Box>
+  )
+}
+
+interface IWorkflowAlerts {
+  labelWidth: string;
+}
+
+const WorkflowAlerts = ({labelWidth}: IWorkflowAlerts) => {
+  const dispatch = useAppDispatch();
+  const settings_onsuccess = useAppSelector(
+    (state) => state.builder.workflow_alerts.onsuccess,
+  );
+  const settings_onerror = useAppSelector(
+    (state) => state.builder.workflow_alerts.onerror,
+  );
+  const theme = useTheme();
+  
+  return (
+    <>
+      <Typography variant="h6">Workflow Alerts</Typography>
+      <Typography variant="body1">
+        Configure email alerts for workflow success and failure.
+      </Typography>
+      <Typography variant="body1" sx={{ color: theme.palette.warning.main }}>
+        Warning: Your email username and password will be stored in a plain text file.
+      </Typography>
+      <FormGroup>
+        <EmailSettings labelWidth={labelWidth} />
+        <FormControlLabel
+          control={
+            <Checkbox
+              id="settings_workflow_alerts_onsuccess_enabled"
+              checked={settings_onsuccess.enabled}
+              onChange={(e) => dispatch(builderToggleWorkflowAlertOnSuccessEnabled(e.target.checked))}
+            />
+          }
+          label="Enable success alert"
+        />
+        {(settings_onsuccess.enabled) ? (
+          <WorkflowAlertSettings
+            labelWidth={labelWidth}
+            alert_type="onsuccess"
+            setSubject={(value: string) => dispatch(builderSetWorkflowAlertsOnSuccessSubject(value))}
+            setBody={(value: string) => dispatch(builderSetWorkflowAlertsOnSuccessBody(value))}
+          />
+        ) : null}
+        <FormControlLabel
+          control={
+            <Checkbox
+              id="settings_workflow_alerts_onerror_enabled"
+              checked={settings_onerror.enabled}
+              onChange={(e) => dispatch(builderToggleWorkflowAlertOnErrorEnabled(e.target.checked))}
+            />
+          }
+          label="Enable failure alert"
+        />
+        {(settings_onerror.enabled) ? (
+          <WorkflowAlertSettings
+            labelWidth={labelWidth}
+            alert_type="onerror"
+            setSubject={(value: string) => dispatch(builderSetWorkflowAlertsOnErrorSubject(value))}
+            setBody={(value: string) => dispatch(builderSetWorkflowAlertsOnErrorBody(value))}
+          />
+        ) : null}
+      </FormGroup>
+    </>
+  )
+}
+
+export default WorkflowAlerts;

--- a/nodemapper/src/gui/Settings/WorkflowAlerts.tsx
+++ b/nodemapper/src/gui/Settings/WorkflowAlerts.tsx
@@ -1,24 +1,27 @@
-import React from 'react';
-import { useAppDispatch, useAppSelector } from 'redux/store/hooks';
-import {
-  builderToggleWorkflowAlertOnSuccessEnabled,
-  builderToggleWorkflowAlertOnErrorEnabled,
-  builderSetWorkflowAlertsEmailSMTPServer,
-  builderSetWorkflowAlertsEmailSMTPPort,
-  builderSetWorkflowAlertsEmailUsername,
-  builderSetWorkflowAlertsEmailPassword,
-  builderSetWorkflowAlertsOnSuccessSubject,
-  builderSetWorkflowAlertsOnSuccessBody,
-  builderSetWorkflowAlertsOnErrorSubject,
-  builderSetWorkflowAlertsOnErrorBody,
-} from 'redux/actions';
-import { useTheme } from '@mui/material/styles';
+import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
-import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
-import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import React from 'react';
+import {
+  builderSetWorkflowAlertsEmailPassword,
+  builderSetWorkflowAlertsEmailSMTPPort,
+  builderSetWorkflowAlertsEmailSMTPServer,
+  builderSetWorkflowAlertsEmailSender,
+  builderSetWorkflowAlertsEmailUsername,
+  builderSetWorkflowAlertsOnErrorBody,
+  builderSetWorkflowAlertsOnErrorRecipients,
+  builderSetWorkflowAlertsOnErrorSubject,
+  builderSetWorkflowAlertsOnSuccessBody,
+  builderSetWorkflowAlertsOnSuccessRecipients,
+  builderSetWorkflowAlertsOnSuccessSubject,
+  builderToggleWorkflowAlertOnErrorEnabled,
+  builderToggleWorkflowAlertOnSuccessEnabled,
+} from 'redux/actions';
+import { useAppDispatch, useAppSelector } from 'redux/store/hooks';
 
 interface IInputItem {
   id: string;
@@ -29,7 +32,7 @@ interface IInputItem {
   labelWidth: string;
 }
 
-const InputItem = ({id, type, label, value, onChange, labelWidth}: IInputItem) => {
+const InputItem = ({ id, type, label, value, onChange, labelWidth }: IInputItem) => {
   if (type === undefined) {
     type = 'text';
   }
@@ -59,18 +62,16 @@ const InputItem = ({id, type, label, value, onChange, labelWidth}: IInputItem) =
         size="small"
       />
     </Box>
-  )
-} 
+  );
+};
 
 interface IEmailSettings {
   labelWidth: string;
 }
 
-const EmailSettings = ({labelWidth}: IEmailSettings) => {
+const EmailSettings = ({ labelWidth }: IEmailSettings) => {
   const dispatch = useAppDispatch();
-  const email_settings = useAppSelector(
-    (state) => state.builder.workflow_alerts.email_settings,
-  );
+  const email_settings = useAppSelector((state) => state.builder.workflow_alerts.email_settings);
   const setSMTPServer = (value: string) => dispatch(builderSetWorkflowAlertsEmailSMTPServer(value));
   const setSMTPPort = (value: string) => {
     if (isNaN(parseInt(value))) {
@@ -81,6 +82,7 @@ const EmailSettings = ({labelWidth}: IEmailSettings) => {
   };
   const setUsername = (value: string) => dispatch(builderSetWorkflowAlertsEmailUsername(value));
   const setPassword = (value: string) => dispatch(builderSetWorkflowAlertsEmailPassword(value));
+  const setSender = (value: string) => dispatch(builderSetWorkflowAlertsEmailSender(value));
 
   return (
     <Box
@@ -103,6 +105,13 @@ const EmailSettings = ({labelWidth}: IEmailSettings) => {
         labelWidth={labelWidth}
       />
       <InputItem
+        id="settings_workflow_alerts_email_sender"
+        label="Sender:"
+        value={email_settings.sender}
+        onChange={(e) => setSender(e.target.value)}
+        labelWidth={labelWidth}
+      />
+      <InputItem
         id="settings_workflow_alerts_email_username"
         label="Username:"
         value={email_settings.username}
@@ -118,21 +127,26 @@ const EmailSettings = ({labelWidth}: IEmailSettings) => {
         labelWidth={labelWidth}
       />
     </Box>
-  )
-}
+  );
+};
 
 interface IWorkflowAlertSettings {
   labelWidth: string;
   alert_type: string;
   setSubject: (value: string) => void;
   setBody: (value: string) => void;
+  setRecipients: (value: string) => void;
 }
 
-const WorkflowAlertSettings = ({labelWidth, alert_type, setSubject, setBody}: IWorkflowAlertSettings) => {
-  const message = useAppSelector(
-    (state) => state.builder.workflow_alerts[alert_type].message,
-  );
-  
+const WorkflowAlertSettings = ({
+  labelWidth,
+  alert_type,
+  setSubject,
+  setBody,
+  setRecipients,
+}: IWorkflowAlertSettings) => {
+  const message = useAppSelector((state) => state.builder.workflow_alerts[alert_type].message);
+
   return (
     <Box
       sx={{
@@ -140,37 +154,40 @@ const WorkflowAlertSettings = ({labelWidth, alert_type, setSubject, setBody}: IW
       }}
     >
       <InputItem
-        id="settings_workflow_alerts_email_subject"
+        id={'settings_workflow_alerts_' + alert_type + '_email_subject'}
         label="Subject:"
         value={message.subject}
         onChange={(e) => setSubject(e.target.value)}
         labelWidth={labelWidth}
       />
       <InputItem
-        id="settings_workflow_alerts_email_message"
+        id={'settings_workflow_alerts_' + alert_type + '_email_message'}
         label="Message:"
         value={message.body}
         onChange={(e) => setBody(e.target.value)}
         labelWidth={labelWidth}
       />
+      <InputItem
+        id={'settings_workflow_alerts_' + alert_type + '_email_recipients'}
+        label="Recipients:"
+        value={message.recipients}
+        onChange={(e) => setRecipients(e.target.value)}
+        labelWidth={labelWidth}
+      />
     </Box>
-  )
-}
+  );
+};
 
 interface IWorkflowAlerts {
   labelWidth: string;
 }
 
-const WorkflowAlerts = ({labelWidth}: IWorkflowAlerts) => {
+const WorkflowAlerts = ({ labelWidth }: IWorkflowAlerts) => {
   const dispatch = useAppDispatch();
-  const settings_onsuccess = useAppSelector(
-    (state) => state.builder.workflow_alerts.onsuccess,
-  );
-  const settings_onerror = useAppSelector(
-    (state) => state.builder.workflow_alerts.onerror,
-  );
+  const settings_onsuccess = useAppSelector((state) => state.builder.workflow_alerts.onsuccess);
+  const settings_onerror = useAppSelector((state) => state.builder.workflow_alerts.onerror);
   const theme = useTheme();
-  
+
   return (
     <>
       <Typography variant="h6">Workflow Alerts</Typography>
@@ -178,7 +195,9 @@ const WorkflowAlerts = ({labelWidth}: IWorkflowAlerts) => {
         Configure email alerts for workflow success and failure.
       </Typography>
       <Typography variant="body1" sx={{ color: theme.palette.warning.main }}>
-        Warning: Your email username and password will be stored in a plain text file.
+        Warning: If entered below your email username and password will be stored in a plain text
+        file. You can alternatively provide them as environment variables `GRAPEVNE_EMAIL_USERNAME`
+        and `GRAPEVNE_EMAIL_PASSWORD` within the execution environment.
       </Typography>
       <FormGroup>
         <EmailSettings labelWidth={labelWidth} />
@@ -187,17 +206,24 @@ const WorkflowAlerts = ({labelWidth}: IWorkflowAlerts) => {
             <Checkbox
               id="settings_workflow_alerts_onsuccess_enabled"
               checked={settings_onsuccess.enabled}
-              onChange={(e) => dispatch(builderToggleWorkflowAlertOnSuccessEnabled(e.target.checked))}
+              onChange={(e) =>
+                dispatch(builderToggleWorkflowAlertOnSuccessEnabled(e.target.checked))
+              }
             />
           }
           label="Enable success alert"
         />
-        {(settings_onsuccess.enabled) ? (
+        {settings_onsuccess.enabled ? (
           <WorkflowAlertSettings
             labelWidth={labelWidth}
             alert_type="onsuccess"
-            setSubject={(value: string) => dispatch(builderSetWorkflowAlertsOnSuccessSubject(value))}
+            setSubject={(value: string) =>
+              dispatch(builderSetWorkflowAlertsOnSuccessSubject(value))
+            }
             setBody={(value: string) => dispatch(builderSetWorkflowAlertsOnSuccessBody(value))}
+            setRecipients={(value: string) =>
+              dispatch(builderSetWorkflowAlertsOnSuccessRecipients(value))
+            }
           />
         ) : null}
         <FormControlLabel
@@ -210,17 +236,20 @@ const WorkflowAlerts = ({labelWidth}: IWorkflowAlerts) => {
           }
           label="Enable failure alert"
         />
-        {(settings_onerror.enabled) ? (
+        {settings_onerror.enabled ? (
           <WorkflowAlertSettings
             labelWidth={labelWidth}
             alert_type="onerror"
             setSubject={(value: string) => dispatch(builderSetWorkflowAlertsOnErrorSubject(value))}
             setBody={(value: string) => dispatch(builderSetWorkflowAlertsOnErrorBody(value))}
+            setRecipients={(value: string) =>
+              dispatch(builderSetWorkflowAlertsOnErrorRecipients(value))
+            }
           />
         ) : null}
       </FormGroup>
     </>
-  )
-}
+  );
+};
 
 export default WorkflowAlerts;

--- a/nodemapper/src/redux/actions/builder.ts
+++ b/nodemapper/src/redux/actions/builder.ts
@@ -68,6 +68,36 @@ export const builderWriteStoreConfig = createAction('builder/write-store-config'
 export const builderToggleDarkMode = createAction('builder/toggle-dark-mode');
 export const builderOpenResultsFolder = createAction('builder/open-results-folder');
 export const builderUpdateWorkdir = createAction<string>('builder/update-workdir');
+export const builderToggleWorkflowAlertOnSuccessEnabled = createAction<boolean>(
+  'builder/toggle-workflow-alert-on-success-enabled'
+);
+export const builderToggleWorkflowAlertOnErrorEnabled = createAction<boolean>(
+  'builder/toggle-workflow-alert-on-error-enabled'
+);
+export const builderSetWorkflowAlertsEmailSMTPServer = createAction<string>(
+  'builder/set-workflow-alerts-email-smtp-server'
+);
+export const builderSetWorkflowAlertsEmailSMTPPort = createAction<string>(
+  'builder/set-workflow-alerts-email-smtp-port'
+);
+export const builderSetWorkflowAlertsEmailUsername = createAction<string>(
+  'builder/set-workflow-alerts-email-username'
+);
+export const builderSetWorkflowAlertsEmailPassword = createAction<string>(
+  'builder/set-workflow-alerts-email-password'
+);
+export const builderSetWorkflowAlertsOnSuccessSubject = createAction<string>(
+  'builder/set-workflow-alerts-onsuccess-subject'
+);
+export const builderSetWorkflowAlertsOnSuccessBody = createAction<string>(
+  'builder/set-workflow-alerts-onsuccess-body'
+);
+export const builderSetWorkflowAlertsOnErrorSubject = createAction<string>(
+  'builder/set-workflow-alerts-onerror-subject'
+);
+export const builderSetWorkflowAlertsOnErrorBody = createAction<string>(
+  'builder/set-workflow-alerts-onerror-body'
+);
 
 export const builderLoadScene = createAction('builder/load-scene');
 export const builderSaveScene = createAction('builder/save-scene');

--- a/nodemapper/src/redux/actions/builder.ts
+++ b/nodemapper/src/redux/actions/builder.ts
@@ -69,34 +69,43 @@ export const builderToggleDarkMode = createAction('builder/toggle-dark-mode');
 export const builderOpenResultsFolder = createAction('builder/open-results-folder');
 export const builderUpdateWorkdir = createAction<string>('builder/update-workdir');
 export const builderToggleWorkflowAlertOnSuccessEnabled = createAction<boolean>(
-  'builder/toggle-workflow-alert-on-success-enabled'
+  'builder/toggle-workflow-alert-on-success-enabled',
 );
 export const builderToggleWorkflowAlertOnErrorEnabled = createAction<boolean>(
-  'builder/toggle-workflow-alert-on-error-enabled'
+  'builder/toggle-workflow-alert-on-error-enabled',
 );
 export const builderSetWorkflowAlertsEmailSMTPServer = createAction<string>(
-  'builder/set-workflow-alerts-email-smtp-server'
+  'builder/set-workflow-alerts-email-smtp-server',
 );
 export const builderSetWorkflowAlertsEmailSMTPPort = createAction<string>(
-  'builder/set-workflow-alerts-email-smtp-port'
+  'builder/set-workflow-alerts-email-smtp-port',
+);
+export const builderSetWorkflowAlertsEmailSender = createAction<string>(
+  'builder/set-workflow-alerts-email-sender',
 );
 export const builderSetWorkflowAlertsEmailUsername = createAction<string>(
-  'builder/set-workflow-alerts-email-username'
+  'builder/set-workflow-alerts-email-username',
 );
 export const builderSetWorkflowAlertsEmailPassword = createAction<string>(
-  'builder/set-workflow-alerts-email-password'
+  'builder/set-workflow-alerts-email-password',
 );
 export const builderSetWorkflowAlertsOnSuccessSubject = createAction<string>(
-  'builder/set-workflow-alerts-onsuccess-subject'
+  'builder/set-workflow-alerts-onsuccess-subject',
 );
 export const builderSetWorkflowAlertsOnSuccessBody = createAction<string>(
-  'builder/set-workflow-alerts-onsuccess-body'
+  'builder/set-workflow-alerts-onsuccess-body',
+);
+export const builderSetWorkflowAlertsOnSuccessRecipients = createAction<string>(
+  'builder/set-workflow-alerts-onsuccess-recipients',
 );
 export const builderSetWorkflowAlertsOnErrorSubject = createAction<string>(
-  'builder/set-workflow-alerts-onerror-subject'
+  'builder/set-workflow-alerts-onerror-subject',
 );
 export const builderSetWorkflowAlertsOnErrorBody = createAction<string>(
-  'builder/set-workflow-alerts-onerror-body'
+  'builder/set-workflow-alerts-onerror-body',
+);
+export const builderSetWorkflowAlertsOnErrorRecipients = createAction<string>(
+  'builder/set-workflow-alerts-onerror-recipients',
 );
 
 export const builderLoadScene = createAction('builder/load-scene');

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -11,6 +11,32 @@ export interface IRepo {
   repo: string;
 }
 
+export interface IWorkflowAlertEmail {
+  smtp_server: string;
+  smtp_port: number;
+
+  username: string;
+  password: string;
+}
+
+export interface IWorkflowAlertMessage {
+  subject: string;
+  body: string;
+  sender: string;
+  recipients: string[];
+}
+
+export interface IWorkflowAlert {
+  enabled: boolean;
+  message: IWorkflowAlertMessage;
+}
+
+export interface IWorkflowAlerts {
+  onsuccess: IWorkflowAlert;
+  onerror: IWorkflowAlert;
+  email_settings: IWorkflowAlertEmail;
+}
+
 export interface IBuilderState {
   // Builder state
   statustext: string;
@@ -38,6 +64,7 @@ export interface IBuilderState {
   auto_validate_connections: boolean;
   hide_params_in_module_info: boolean;
   dark_mode: boolean;
+  workflow_alerts: IWorkflowAlerts;
 }
 
 // Defaults
@@ -80,6 +107,32 @@ const builderStateInit: IBuilderState = {
   auto_validate_connections: false,
   hide_params_in_module_info: true,
   dark_mode: false,
+  workflow_alerts: {
+    onsuccess: {
+      enabled: false,
+      message: {
+        subject: 'Workflow completed successfully',
+        body: 'Workflow completed successfully',
+        sender: '',
+        recipients: [''],
+      },
+    },
+    onerror: {
+      enabled: false,
+      message: {
+        subject: 'Workflow failure',
+        body: 'Workflow failure',
+        sender: '',
+        recipients: [''],
+      },
+    },
+    email_settings: {
+      smtp_server: 'smtp.gmail.com',
+      smtp_port: 587,
+      username: '',
+      password: '',
+    },
+  },
 };
 
 // Nodemap
@@ -227,6 +280,46 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
     })
     .addCase(actions.builderBuildInProgress, (state, action) => {
       state.build_in_progress = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderToggleWorkflowAlertOnSuccessEnabled, (state, action) => {
+      state.workflow_alerts.onsuccess.enabled = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderToggleWorkflowAlertOnErrorEnabled, (state, action) => {
+      state.workflow_alerts.onerror.enabled = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsEmailSMTPServer, (state, action) => {
+      state.workflow_alerts.email_settings.smtp_server = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsEmailSMTPPort, (state, action) => {
+      state.workflow_alerts.email_settings.smtp_port = parseInt(action.payload);
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsEmailUsername, (state, action) => {
+      state.workflow_alerts.email_settings.username = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsEmailPassword, (state, action) => {
+      state.workflow_alerts.email_settings.password = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsOnSuccessSubject, (state, action) => {
+      state.workflow_alerts.onsuccess.message.subject = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsOnSuccessBody, (state, action) => {
+      state.workflow_alerts.onsuccess.message.body = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsOnErrorSubject, (state, action) => {
+      state.workflow_alerts.onerror.message.subject = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsOnErrorBody, (state, action) => {
+      state.workflow_alerts.onerror.message.body = action.payload;
       console.info('[Reducer] ' + action.type);
     });
 });

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -14,7 +14,7 @@ export interface IRepo {
 export interface IWorkflowAlertEmail {
   smtp_server: string;
   smtp_port: number;
-
+  sender: string;
   username: string;
   password: string;
 }
@@ -22,8 +22,7 @@ export interface IWorkflowAlertEmail {
 export interface IWorkflowAlertMessage {
   subject: string;
   body: string;
-  sender: string;
-  recipients: string[];
+  recipients: string;
 }
 
 export interface IWorkflowAlert {
@@ -108,13 +107,19 @@ const builderStateInit: IBuilderState = {
   hide_params_in_module_info: true,
   dark_mode: false,
   workflow_alerts: {
+    email_settings: {
+      smtp_server: 'smtp.gmail.com',
+      smtp_port: 587,
+      sender: '',
+      username: '',
+      password: '',
+    },
     onsuccess: {
       enabled: false,
       message: {
         subject: 'Workflow completed successfully',
         body: 'Workflow completed successfully',
-        sender: '',
-        recipients: [''],
+        recipients: '',
       },
     },
     onerror: {
@@ -122,15 +127,8 @@ const builderStateInit: IBuilderState = {
       message: {
         subject: 'Workflow failure',
         body: 'Workflow failure',
-        sender: '',
-        recipients: [''],
+        recipients: '',
       },
-    },
-    email_settings: {
-      smtp_server: 'smtp.gmail.com',
-      smtp_port: 587,
-      username: '',
-      password: '',
     },
   },
 };
@@ -298,6 +296,10 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
       state.workflow_alerts.email_settings.smtp_port = parseInt(action.payload);
       console.info('[Reducer] ' + action.type);
     })
+    .addCase(actions.builderSetWorkflowAlertsEmailSender, (state, action) => {
+      state.workflow_alerts.email_settings.sender = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
     .addCase(actions.builderSetWorkflowAlertsEmailUsername, (state, action) => {
       state.workflow_alerts.email_settings.username = action.payload;
       console.info('[Reducer] ' + action.type);
@@ -314,12 +316,20 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
       state.workflow_alerts.onsuccess.message.body = action.payload;
       console.info('[Reducer] ' + action.type);
     })
+    .addCase(actions.builderSetWorkflowAlertsOnSuccessRecipients, (state, action) => {
+      state.workflow_alerts.onsuccess.message.recipients = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
     .addCase(actions.builderSetWorkflowAlertsOnErrorSubject, (state, action) => {
       state.workflow_alerts.onerror.message.subject = action.payload;
       console.info('[Reducer] ' + action.type);
     })
     .addCase(actions.builderSetWorkflowAlertsOnErrorBody, (state, action) => {
       state.workflow_alerts.onerror.message.body = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetWorkflowAlertsOnErrorRecipients, (state, action) => {
+      state.workflow_alerts.onerror.message.recipients = action.payload;
       console.info('[Reducer] ' + action.type);
     });
 });


### PR DESCRIPTION
Enable workflow alerts. These run on either sucessful completion, or upon failure.

Workflow alerts are currently limited to email notifications. Workflow alerts are defined in GRAPEVNE Settings. The username and password can be entered in the editor for testing, but can also be set by environment variables for deployment.

<img width="631" alt="Screenshot 2024-07-01 at 22 31 27" src="https://github.com/kraemer-lab/GRAPEVNE/assets/98161205/f36f8c44-afee-4678-a1d1-0533899ae8db">

Resolves #281 