### PR TITLE
Add manifest support and selectable configuration files

### DIFF
--- a/electron-app/src/api.ts
+++ b/electron-app/src/api.ts
@@ -21,6 +21,7 @@ export type BuilderAPI = {
   CleanBuildFolder: (query: Query) => Promise<Query>;
   GetRemoteModules: (query: Query) => Promise<Query>;
   GetRemoteModuleConfig: (query: Query) => Promise<Query>;
+  GetModuleConfigFilesList: (query: Query | string) => Promise<string[]>;
   OpenResultsFolder: (workdir: string) => Promise<Query>;
   logEvent: (callback: (event: Event, data: string) => void) => void;
 };

--- a/electron-app/src/api.ts
+++ b/electron-app/src/api.ts
@@ -24,6 +24,8 @@ export type BuilderAPI = {
   GetModuleConfigFilesList: (query: Query | string) => Promise<string[]>;
   OpenResultsFolder: (workdir: string) => Promise<Query>;
   logEvent: (callback: (event: Event, data: string) => void) => void;
+  GetFile: (filename: string) => Promise<string>;
+  GetConfigFilenameFromSnakefile: (filename: Query | string) => Promise<string>;
 };
 
 export type RunnerAPI = {

--- a/electron-app/src/handles.ts
+++ b/electron-app/src/handles.ts
@@ -1,6 +1,7 @@
 import Store from 'electron-store';
 import fs from 'fs';
 import web from './web';
+import axios from 'axios';
 
 import { dialog, IpcMainInvokeEvent, shell } from 'electron';
 import { Build, CondaSearch, INewModuleState } from './newmodule';
@@ -242,6 +243,26 @@ export async function builder_CleanBuildFolder(
 export async function builder_OpenResultsFolder(event: Event, workdir: string) {
   shell.showItemInFolder(workdir);
   return { query: 'builder/open-results-folder', body: 'OK', returncode: 0 };
+}
+
+export async function builder_GetFile(event: Event, filename: string): Promise<string> {
+  if (filename.startsWith('http')) {
+    // Remote filename
+    try {
+      const response = await axios.get(filename);
+      return response.data;
+    } catch (err) {
+      console.error('Error getting remote file: ' + filename);
+      return '';
+    }
+  } else {
+    // Local file
+    return fs.readFileSync(filename as string, { encoding: 'utf8' });
+  }
+}
+
+export async function builder_GetConfigFilenameFromSnakefile(event: Event, snakefile: Query | string) {
+  return await web.getConfigFilenameFromSnakefile(snakefile);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/electron-app/src/handles.ts
+++ b/electron-app/src/handles.ts
@@ -117,6 +117,10 @@ export async function builder_GetRemoteModuleConfig(event: Event, query: Query) 
   return config;
 }
 
+export async function builder_GetModuleConfigFilesList(event: Event, snakefile: Query | string) {
+  return await web.GetModuleConfigFilesList(snakefile);
+}
+
 export async function builder_BuildAsModule(
   event: Event,
   query: Query,

--- a/electron-app/src/main.ts
+++ b/electron-app/src/main.ts
@@ -142,6 +142,12 @@ app.whenReady().then(() => {
     handles.builder_CleanBuildFolder(event, data, status_callback),
   );
   ipcMain.handle('builder/open-results-folder', handles.builder_OpenResultsFolder);
+  ipcMain.handle('builder/get-file', (event: Event, filename: string) =>
+    handles.builder_GetFile(event, filename),
+  );
+  ipcMain.handle('builder/get-config-filename-from-snakefile', (event: Event, data: Query | string) =>
+     handles.builder_GetConfigFilenameFromSnakefile(event, data),
+  );
 
   // Runner
   ipcMain.handle('runner/build', (event: Event, data: Query) =>

--- a/electron-app/src/main.ts
+++ b/electron-app/src/main.ts
@@ -128,6 +128,7 @@ app.whenReady().then(() => {
   // Builder
   ipcMain.handle('builder/get-remote-modules', handles.builder_GetRemoteModules);
   ipcMain.handle('builder/get-remote-module-config', handles.builder_GetRemoteModuleConfig);
+  ipcMain.handle('builder/get-module-config-files-list', handles.builder_GetModuleConfigFilesList);
   ipcMain.handle('builder/build-as-module', (event: Event, data: Query) =>
     handles.builder_BuildAsModule(event, data, stderr_callback),
   );

--- a/electron-app/src/preload.ts
+++ b/electron-app/src/preload.ts
@@ -26,6 +26,7 @@ contextBridge.exposeInMainWorld('builderAPI', {
   GetRemoteModules: (query: Query) => ipcRenderer.invoke('builder/get-remote-modules', query),
   GetRemoteModuleConfig: (query: Query) =>
     ipcRenderer.invoke('builder/get-remote-module-config', query),
+  GetModuleConfigFilesList: (query: Query | string) => ipcRenderer.invoke('builder/get-module-config-files-list', query),
   OpenResultsFolder: (workdir: string) =>
     ipcRenderer.invoke('builder/open-results-folder', workdir),
   logEvent: (callback: (event: Event, data: string) => void) =>

--- a/electron-app/src/preload.ts
+++ b/electron-app/src/preload.ts
@@ -31,6 +31,8 @@ contextBridge.exposeInMainWorld('builderAPI', {
     ipcRenderer.invoke('builder/open-results-folder', workdir),
   logEvent: (callback: (event: Event, data: string) => void) =>
     ipcRenderer.on('builder/log-event', callback),
+  GetFile: (filename: string) => ipcRenderer.invoke('builder/get-file', filename),
+  GetConfigFilenameFromSnakefile: (filename: Query | string) => ipcRenderer.invoke('builder/get-config-filename-from-snakefile', filename),
 });
 
 contextBridge.exposeInMainWorld('runnerAPI', {

--- a/electron-app/src/web.ts
+++ b/electron-app/src/web.ts
@@ -3,7 +3,9 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 
-const load_config = false;
+const url_github = 'https://api.github.com/repos';
+let manifest: Record<string, unknown> = {};
+const manifest_path = 'manifest.json';
 
 const GetModuleConfig = async (
   repo: Record<string, unknown>,
@@ -172,14 +174,6 @@ const GetLocalModules = (root_folder: string): Array<Record<string, unknown>> =>
 
         let config = {};
         let module_classification = module_type.slice(0, -1); // remove plural
-        if (load_config) {
-          try {
-            config = yaml.load(fs.readFileSync(config_file, 'utf8')) as Record<string, unknown>;
-          } catch (err) {
-            console.log('No (or invalid YAML) config file found.');
-          }
-          module_classification = GetModuleClassification(config);
-        }
         modules.push({
           name: FormatName(workflow),
           type: module_classification,
@@ -214,24 +208,106 @@ const GetRemoteModulesGithub = async (
   }
 };
 
+const checkManifest = (repo: string, branch: string) => {
+  Object.keys(manifest).forEach((key) => {
+    if (key === repo) {
+      if (manifest[key])
+        return true;
+    }
+  });
+  return false;
+}
+
+const populateManifest = async (repo: string, branch: string) => {
+  // Check if manifest already exists
+  if (!checkManifest(repo, branch)) {
+    // Attempt to populate manifest file
+    const manifest_url = ['https://raw.githubusercontent.com', repo, branch, manifest_path].join('/');
+    const response = await axios.get(manifest_url)
+      .then((response) => response.data)
+      .then((data) => {
+        console.log('Got manifest data: ', data);
+        // may return undefined
+        if (data) {
+          manifest[repo] = data;
+        }
+      })
+      .catch((e) => {
+        console.log('Could not retrieve manifest file: ', e);
+      });
+  }
+}
+
+const getManifest = (repo: string, branch: string): Record<string, unknown> => {
+  if (!checkManifest(repo, branch)) {
+    return manifest[repo] as Record<string, unknown>;
+  } else {
+    return {};
+  }
+}
+  
+const api_get = async (url: string, url_base: string): Promise<Record<string, string>[]> => {
+  // Attempt to look up folder contents in the manifest file; if the manifest file does
+  // not exist, then resort to an API request (these can be rate limited)
+
+  if (url.includes(url_github)) {
+    // Extract repo from url
+    const repo = url.replace(url_github + "/", '').split('/').slice(0, 2).join('/');
+    const branch = "main";  // only main branch manifest is available
+    const manifest_repo = getManifest(repo, branch);
+    if (Object.keys(manifest_repo).length > 0) {
+      // Look up item in manifest file
+      console.debug('Looking up in manifest: ', url);
+      const manifest_key = url.replace(url_base, '');
+      const path = manifest_key.split('/').filter((item) => item !== '');
+      let contents = manifest_repo['children'] as Record<string, unknown>[];
+      let workflows = contents.find((item: Record<string, unknown>) => item['name'] === 'workflows') as Record<string, unknown>;
+      let data = workflows['children'] as Record<string, unknown>[];
+      for (const p of path) {
+        const datum = data.find((item: Record<string, unknown>) => item['name'] === p);
+        if (!datum) {
+          console.debug('Could not find item in manifest: ', p);
+          return [];
+        }
+        data = datum['children'] as Record<string, unknown>[];
+      }
+      // Format data for return
+      const out: Record<string, string>[] = [];
+      for (const item of data) {
+        if (item['type'] === 'folder')
+          item['type'] = 'dir';
+        out.push({
+          name: item['name'] as string,
+          type: item['type'] as string,
+        });
+      }
+      return out;
+    }
+  }  
+  // API request (risks hitting github rate limit)
+  const response = await axios.get(url);
+  return await response.data;
+}
+
 const GetRemoteModulesGithubDirectoryListing = async (
   repo: string,
 ): Promise<Record<string, unknown>[]> => {
-  const url_github = 'https://api.github.com/repos';
-  const url_base: string = path.join(url_github, repo, 'contents/workflows');
+  const url_base: string = [url_github, repo, 'contents/workflows'].join('/');
   const branch = 'main';
   const modules: Array<Record<string, unknown>> = [];
 
+  // Attempt to populate manifest (if it does not already exist)
+  await populateManifest(repo, branch);
+
+  // Redirect get request to allow manifest intercept if possible
   async function get(url: string) {
-    const response = await axios.get(url);
-    return await response.data;
+    return api_get(url, url_base);
   }
 
-  // Get latest commit of main branch
-  const commit = await get(path.join(url_github, repo, 'commits', branch))
+  // Get latest commit of main branch (explit use of axios here; not manifest)
+  const commit = await axios.get([url_github, repo, "commits", branch].join('/'))
+    .then((response) => response.data)
     .then((data) => {
-      console.log(data);
-      console.log('Latest commit: ', data['sha']);
       return data['sha'];
     })
     .catch(() => {
@@ -242,30 +318,30 @@ const GetRemoteModulesGithubDirectoryListing = async (
   // First-level (organisation) listing
   const orgs = await get(url_base).then((data) => {
     return data
-      .filter((org: Record<string, unknown>) => org['type'] == 'dir')
-      .map((org: Record<string, unknown>) => org['name']);
+      .filter((org: Record<string, string>) => org['type'] == 'dir')
+      .map((org: Record<string, string>) => org['name']);
   });
   for (const org of orgs) {
-    const url_org = path.join(url_base, org);
+    const url_org = [url_base, org].join('/');
     const module_types = await get(url_org).then((data) => {
       return data
-        .filter((module_type: Record<string, unknown>) => module_type['type'] == 'dir')
-        .map((module_type: Record<string, unknown>) => module_type['name'])
+        .filter((module_type: Record<string, string>) => module_type['type'] == 'dir')
+        .map((module_type: Record<string, string>) => module_type['name'])
         .reverse();
     });
 
     // Second-level (module type) listing
     for (const module_type of module_types) {
-      const url_workflow = path.join(url_org, module_type);
+      const url_workflow = [url_org, module_type].join('/');
       const workflows = await get(url_workflow).then((data) => {
         return data
-          .filter((workflow: Record<string, unknown>) => workflow['type'] == 'dir')
-          .map((workflow: Record<string, unknown>) => workflow['name']);
+          .filter((workflow: Record<string, string>) => workflow['type'] == 'dir')
+          .map((workflow: Record<string, string>) => workflow['name']);
       });
 
       // Third-level (module/workflow) listing
       for (const workflow of workflows) {
-        const url_config = path.join(
+        const url_config = [
           'https://raw.githubusercontent.com',
           repo,
           branch,
@@ -274,21 +350,10 @@ const GetRemoteModulesGithubDirectoryListing = async (
           module_type,
           workflow,
           'config/config.yaml',
-        );
+        ].join('/');
 
         let config = {};
         let module_classification = module_type.slice(0, -1);
-        if (load_config) {
-          config = await get(url_config)
-            .then((data) => {
-              return yaml.load(data) as Record<string, unknown>;
-            })
-            .catch(() => {
-              console.log('No (or invalid YAML) config file found.');
-              return {};
-            });
-          module_classification = GetModuleClassification(config);
-        }
         let snakefile = {};
         // If commit is specified, use that, otherwise use branch
         if (commit !== '') {
@@ -369,17 +434,6 @@ const GetRemoteModulesGithubBranchListing = async (
     );
     let config = {};
     let module_classification = module_types[module_type as keyof typeof module_types];
-    if (load_config) {
-      config = await get(url_config)
-        .then((data) => {
-          return yaml.load(data) as Record<string, unknown>;
-        })
-        .catch(() => {
-          console.log('No (or invalid YAML) config file found.');
-          return {};
-        });
-      module_classification = GetModuleClassification(config);
-    }
     const module = {
       name: FormatName(module_name),
       type: module_classification,
@@ -424,6 +478,117 @@ const GetModuleClassification = (config: Record<string, unknown>): string => {
   return 'module';
 };
 
+const getBranchOrCommit = (snakefile: Record<string, unknown>) => {
+  const kwargs = snakefile.kwargs as Record<string, string>;
+  if (Object.hasOwn(kwargs, 'commit')) {
+    return kwargs['commit'];
+  } else if (Object.hasOwn(kwargs, 'branch')) {
+    return kwargs['branch'];
+  } else {
+    throw new Error('Branch or commit not specified');
+  }
+}
+
+const getConfigFilenameFromSnakefile = async(
+  snakefile: Record<string, unknown> | string | null,
+): Promise<string | null> => {
+  if (typeof snakefile === 'string') {
+    // Local repository
+    return getConfigFilenameFromSnakefile_Local(snakefile as string);
+  } else {
+    // Remote repository
+    return getConfigFilenameFromSnakefile_Remote(snakefile as Record<string, unknown>);
+  }
+}
+
+const getConfigFilenameFromSnakefile_Local = (filepath: string): string | null => {
+  const data = fs.readFileSync(filepath, 'utf8');
+  const lines = data.split(/\r?\n/);
+  const configLine = lines.find(line => line.startsWith('configfile:'));
+  if (configLine) {
+    const value = configLine.split('configfile: ')[1].trim();
+    return value;
+  }
+  return null;
+}
+
+const getConfigFilenameFromSnakefile_Remote = async(
+  snakefile: Record<string, unknown>,
+): Promise<string | null> => {
+  // Remote repository
+  snakefile = snakefile as Record<string, unknown>;
+  const snakefile_rel =
+    (snakefile.args as string[])[0] +
+    '/' + getBranchOrCommit(snakefile) +
+    '/' + (snakefile.kwargs as Record<string, string>)['path'];
+  const snakefile_url = 'https://raw.githubusercontent.com/' + snakefile_rel;
+  const data = await axios.get(snakefile_url).then(response => response.data);
+  const lines = data.split(/\r?\n/);
+  const configLine = lines.find((line: string) => line.startsWith('configfile:'));
+  if (configLine) {
+    const value = configLine.split('configfile: ')[1].trim().slice(1, -1);  // remove quotes
+    return value;
+  }
+  return null;
+}
+
+const GetModuleConfigFilesList = async (
+  snakefile: Record<string, unknown> | string,
+) => {
+  // Get list of available config.yaml files from config folder.
+  // Should work got either local or remote repositories
+
+  const configfile = getConfigFilenameFromSnakefile(snakefile);
+  const configfiles_list: string[] = [];
+
+  if (typeof snakefile === 'string') {
+    // Local repository
+    const workflow_url = snakefile as string;
+    const configfile_relative = await getConfigFilenameFromSnakefile(workflow_url);
+    if (configfile_relative) {
+      const configfile = path.join(path.dirname(workflow_url), '..', configfile_relative);
+      const configfile_path = path.dirname(configfile);
+      const configfiles = fs.readdirSync(configfile_path);
+      for (const file of configfiles) {
+        if (file.endsWith('.yaml')) {
+          configfiles_list.push(path.join(configfile_path, file));
+        }
+      }
+    }
+  } else {
+    // Remote repository
+    snakefile = snakefile as Record<string, unknown>;
+    const workflow_path = (snakefile['kwargs'] as Record<string, string>)['path'];
+    const configfile_rel = await getConfigFilenameFromSnakefile(snakefile);
+    if (configfile_rel) {
+      const branch = "main";
+      const configfile_path = [
+        url_github,
+        (snakefile['args'] as string[])[0],
+        branch,
+        'contents',
+        workflow_path.split('/').slice(0, -2).join('/'),
+        configfile_rel.split('/').slice(0, -1).join('/'),
+      ].join('/');
+      const url_base = [
+        url_github,
+        (snakefile['args'] as string[])[0],
+        branch,
+        'contents',
+        'workflows',
+      ].join('/');
+      const configfiles = await api_get(configfile_path, url_base);
+      for (const file of configfiles) {
+        if (file['name'].endsWith('.yaml')) {
+          configfiles_list.push(file['name']);
+        }
+      }
+    }
+  }
+
+  return configfiles_list;
+};
+
 export {
   GetLocalModules,
   GetModuleConfig,
@@ -431,6 +596,7 @@ export {
   GetModuleDocstring,
   GetModulesList,
   GetRemoteModulesGithubDirectoryListing,
+  GetModuleConfigFilesList,
   ParseDocstring,
 };
 module.exports = {
@@ -440,6 +606,7 @@ module.exports = {
   ParseDocstring,
   GetLocalModules,
   GetModulesList,
+  GetModuleConfigFilesList,
   GetRemoteModulesGithubDirectoryListing,
 };
 export default module.exports;

--- a/electron-app/src/web.ts
+++ b/electron-app/src/web.ts
@@ -244,7 +244,7 @@ const getManifest = (repo: string, branch: string): Record<string, unknown> => {
     return {};
   }
 }
-  
+
 const api_get = async (url: string, url_base: string): Promise<Record<string, string>[]> => {
   // Attempt to look up folder contents in the manifest file; if the manifest file does
   // not exist, then resort to an API request (these can be rate limited)
@@ -282,7 +282,7 @@ const api_get = async (url: string, url_base: string): Promise<Record<string, st
       }
       return out;
     }
-  }  
+  }
   // API request (risks hitting github rate limit)
   const response = await axios.get(url);
   return await response.data;

--- a/nodemapper/src/NodeMap/scene/Module.tsx
+++ b/nodemapper/src/NodeMap/scene/Module.tsx
@@ -13,7 +13,7 @@ type ModuleUserConfigType = {
 
 // Module configuration, as appears in the config.yaml file
 type ModuleConfigType = {
-  snakefile: string;
+  snakefile: string | Record<string, string>;
   docstring?: string | null;
   config: ModuleUserConfigType;
 };

--- a/nodemapper/src/api.ts
+++ b/nodemapper/src/api.ts
@@ -21,6 +21,7 @@ export type BuilderAPI = {
   CleanBuildFolder: (query: Query) => Promise<Query>;
   GetRemoteModules: (query: Query) => Promise<Query>;
   GetRemoteModuleConfig: (query: Query) => Promise<Query>;
+  GetModuleConfigFilesList: (query: Query | string) => Promise<string[]>;
   OpenResultsFolder: (workdir: string) => Promise<Query>;
   logEvent: (callback: (event: Event, data: string) => void) => void;
 };

--- a/nodemapper/src/api.ts
+++ b/nodemapper/src/api.ts
@@ -24,6 +24,8 @@ export type BuilderAPI = {
   GetModuleConfigFilesList: (query: Query | string) => Promise<string[]>;
   OpenResultsFolder: (workdir: string) => Promise<Query>;
   logEvent: (callback: (event: Event, data: string) => void) => void;
+  GetFile: (filename: string) => Promise<string>;
+  GetConfigFilenameFromSnakefile: (filename: Query | string) => Promise<string>;
 };
 
 export type RunnerAPI = {

--- a/nodemapper/src/gui/Builder/components/Flow.tsx
+++ b/nodemapper/src/gui/Builder/components/Flow.tsx
@@ -10,6 +10,7 @@ import {
   builderSetEdges,
   builderSetNodes,
   builderUpdateStatusText,
+  builderSetConfigFiles,
 } from 'redux/actions';
 
 import Box from '@mui/material/Box';
@@ -374,6 +375,11 @@ export const setNodeWorkflow = (
   });
 };
 
+const getConfigFiles = async (snakefile: Record<string, unknown> | string): Promise<string[]> => {
+  console.log('Getting config files for: ', snakefile);
+  return await builderAPI.GetModuleConfigFilesList(snakefile);
+}
+
 const Flow = () => {
   const dispatch = useAppDispatch();
   const nodes = useAppSelector((state) => state.builder.nodes);
@@ -527,6 +533,12 @@ const Flow = () => {
           },
         },
       };
+      let snakefile = null;
+      if (typeof workflow['snakefile'] === 'string') {
+        snakefile = workflow['snakefile'] as string;
+      } else {
+        snakefile = workflow['snakefile'] as Query;
+      }
       const getConfig = async (query) => {
         return await builderAPI.GetRemoteModuleConfig(query);
       };
@@ -553,6 +565,11 @@ const Flow = () => {
           // Add node to graph
           dispatch(builderAddNode(newnode));
           dispatch(builderUpdateStatusText(`Module loaded.`));
+          // Get configuration file list (alternative config files)
+          getConfigFiles(snakefile)
+            .then((configfile_list) => {
+              dispatch(builderSetConfigFiles(configfile_list));
+            });
         })
         .catch((error) => {
           console.error(error);
@@ -569,6 +586,8 @@ const Flow = () => {
         position: point,
       } as Node;
       dispatch(builderAddNode(newnode));
+      // Set configuration file list (alternative config files) empty
+      dispatch(builderSetConfigFiles([]));
     }
     document.body.style.cursor = 'default';
   };

--- a/nodemapper/src/gui/Builder/components/Flow.tsx
+++ b/nodemapper/src/gui/Builder/components/Flow.tsx
@@ -14,7 +14,7 @@ import {
 } from 'redux/actions';
 
 import Box from '@mui/material/Box';
-import { Edge, Node, NodeData } from 'NodeMap/scene/Flow'; // Custom Node definition
+import { Edge, Node, NodeData } from 'NodeMap/scene/Flow';  // Custom Node definition
 
 import { toPng, toSvg } from 'html-to-image';
 import ReactFlow, {

--- a/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
@@ -13,7 +13,7 @@ const ConfigSelect = () => {
   const configfiles_list_state = useAppSelector((state) => state.builder.configfiles_list);
   const configfiles_list = [...configfiles_list_state, "(Select file)"];
   const configfiles_names = configfiles_list.map((configfile) => configfile.split("/").pop());
-  
+
   const default_configfile = configfiles_names[0] ?? "";
   const [value, setValue] = useState(default_configfile);
 

--- a/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import { useAppSelector } from "redux/store/hooks";
+
+const ConfigSelect = () => {
+  const configfiles_list = useAppSelector((state) => state.builder.configfiles_list);
+  const configfiles_names = configfiles_list.map((configfile) => configfile.split("/").pop());
+
+  return (
+    <Select
+      labelId="config-file-select"
+      id="config-file-select"
+      value={"config.yaml"}
+      onChange={(event) => {
+        console.log(event.target.value);
+      }}
+      variant={"outlined"}
+      size={"small"}
+    >
+      {configfiles_names.map((configfile) => (
+        <MenuItem key={configfile} value={configfile}>
+          {configfile}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+export default ConfigSelect;

--- a/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/ConfigSelect.tsx
@@ -1,20 +1,71 @@
-import React from "react";
+import React, {useState} from "react";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
-import { useAppSelector } from "redux/store/hooks";
+import { useAppDispatch, useAppSelector } from "redux/store/hooks";
+import { builderUpdateNodeInfoKey } from "redux/actions/builder";
+import yaml from "yaml";
+
+const displayAPI = window.displayAPI;
+const builderAPI = window.builderAPI;
 
 const ConfigSelect = () => {
-  const configfiles_list = useAppSelector((state) => state.builder.configfiles_list);
+  const dispatch = useAppDispatch();
+  const configfiles_list_state = useAppSelector((state) => state.builder.configfiles_list);
+  const configfiles_list = [...configfiles_list_state, "(Select file)"];
   const configfiles_names = configfiles_list.map((configfile) => configfile.split("/").pop());
+  
+  const default_configfile = configfiles_names[0] ?? "";
+  const [value, setValue] = useState(default_configfile);
+
+  const ParseAndModifyConfig = (contents: string) => {
+    // Overwrite parameters structure (note: should use key-matching validation here)
+    const params = yaml.parse(contents);
+    const keylist = ['config'];
+    const key = 'params';
+    const value = params;
+    dispatch(builderUpdateNodeInfoKey({ keys: [...keylist, key], value: value }));
+  }
+
+  const ReadAndModifyConfig = (filename: string) => {
+    // Read select config file
+    builderAPI.GetFile(filename)
+      .then((contents) => {
+        // Parse and update current configuration
+        ParseAndModifyConfig(contents);
+      })
+      .catch((error) => {
+        console.log('Cannot read configuration file: ', error);
+      });
+  }
+
+  const OnChange = (newvalue: string) => {
+    // Check if "(Select file)" has been selected
+    if (newvalue === "(Select file)") {
+      // Poll user for filename
+      displayAPI.SelectFile(value)
+        .then((filename) => ReadAndModifyConfig(filename[0]))
+        .catch((error) => {
+          console.log('Cannot select configuration file: ', error);
+          return;
+        });
+    }
+
+    // Get full filename associated with item
+    const index = configfiles_names.indexOf(newvalue);
+    const fullfile = configfiles_list[index];
+
+    // Read select config file
+    ReadAndModifyConfig(fullfile);
+    // Update selection value
+    setValue(newvalue);
+  }
 
   return (
     <Select
       labelId="config-file-select"
       id="config-file-select"
-      value={"config.yaml"}
-      onChange={(event) => {
-        console.log(event.target.value);
-      }}
+      value={value}
+      onChange={(event) => { OnChange(event.target.value) }}
       variant={"outlined"}
       size={"small"}
     >

--- a/nodemapper/src/gui/Builder/components/NodeInfo/NodeInfo.tsx
+++ b/nodemapper/src/gui/Builder/components/NodeInfo/NodeInfo.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ResizeHandle from './../ResizeHandle';
 import styles from './../styles.module.css';
 import HighlightedJSON from './HighlightedJSON';
+import ConfigSelect from './ConfigSelect';
 
 import { useEffect, useState } from 'react';
 import { Panel, PanelGroup } from 'react-resizable-panels';
@@ -88,6 +89,7 @@ const NodeInfo = () => {
             overflowY: 'auto',
           }}
         >
+          <ConfigSelect />
           <HighlightedJSON nodeid={JSON.parse(nodeinfo).id} json={nodeparams} />
         </Panel>
       </PanelGroup>

--- a/nodemapper/src/redux/actions/builder.ts
+++ b/nodemapper/src/redux/actions/builder.ts
@@ -64,6 +64,7 @@ export const builderUpdateSettings =
   createAction<Record<string, unknown>>('builder/update-settings');
 export const builderReadStoreConfig = createAction('builder/read-store-config');
 export const builderWriteStoreConfig = createAction('builder/write-store-config');
+export const builderSetConfigFiles = createAction<string[]>('builder/set-config-files');
 
 export const builderToggleDarkMode = createAction('builder/toggle-dark-mode');
 export const builderOpenResultsFolder = createAction('builder/open-results-folder');

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -48,6 +48,7 @@ export interface IBuilderState {
   workdir: string;
   modules_loading: boolean;
   build_in_progress: boolean;
+  configfiles_list: string[];
 
   // react-flow parameters
   nodes: Node[];
@@ -83,6 +84,7 @@ const builderStateInit: IBuilderState = {
   workdir: '',
   modules_loading: false,
   build_in_progress: false,
+  configfiles_list: [],
 
   // react-flow parameters
   nodes: default_nodes,
@@ -330,6 +332,10 @@ const builderReducer = createReducer(builderStateInit, (builder) => {
     })
     .addCase(actions.builderSetWorkflowAlertsOnErrorRecipients, (state, action) => {
       state.workflow_alerts.onerror.message.recipients = action.payload;
+      console.info('[Reducer] ' + action.type);
+    })
+    .addCase(actions.builderSetConfigFiles, (state, action) => {
+      state.configfiles_list = action.payload;
       console.info('[Reducer] ' + action.type);
     });
 });


### PR DESCRIPTION
- Manifest support permits those repositories with manifest.json files to be browsed via the downloaded file, rather than a large number of github api calls.
- Selectable configuration files allows the in-editor parameters to be switch between sets of defaults (or user provided parameter sets)

User-interface for configuration file selection:
![Screenshot 2024-07-02 at 17 42 51](https://github.com/kraemer-lab/GRAPEVNE/assets/98161205/48176247-1c61-45d9-9a03-b6bffec02129)

Resolves #280 