### PR TITLE
Add vneyard module search page

### DIFF
--- a/nodemapper/src/gui/Navigation.tsx
+++ b/nodemapper/src/gui/Navigation.tsx
@@ -3,6 +3,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import BuildIcon from '@mui/icons-material/Schema';
 import SettingsIcon from '@mui/icons-material/Settings';
+import VneyardIcon from '@mui/icons-material/Storage';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
 import Divider from '@mui/material/Divider';
@@ -16,6 +17,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { CSSObject, Theme, styled } from '@mui/material/styles';
 import * as React from 'react';
 import Builder from './Builder/Builder';
+import Vneyard from './Vneyard/Vneyard';
 import ModuleEditor from './ModuleEditor/ModuleEditor';
 import Settings from './Settings/Settings';
 
@@ -122,6 +124,8 @@ export default function Navigation() {
     switch (selected) {
       case 'Canvas':
         return <Builder />;
+      case 'Vneyard':
+        return <Vneyard />;
       case 'Settings':
         return <Settings />;
       case 'Module Editor':
@@ -147,6 +151,16 @@ export default function Navigation() {
             id="btnSidenavBuilder"
             text="Canvas"
             Icon={BuildIcon}
+            open={open}
+            onClick={handleListItemClick}
+          />
+        </List>
+        <Divider />
+        <List>
+          <NavItem
+            id="btnSidenavVneyard"
+            text="Vneyard"
+            Icon={VneyardIcon}
             open={open}
             onClick={handleListItemClick}
           />

--- a/nodemapper/src/gui/Vneyard/Vneyard.tsx
+++ b/nodemapper/src/gui/Vneyard/Vneyard.tsx
@@ -14,7 +14,7 @@ const Vineyard = () => {
       }}
     >
       <iframe
-        src={vneyard_url}
+        src={vneyard_url + '?no-cache=' + new Date().getTime() /* prevents caching */}
         style={{
           width: '100%',
           height: '100%',

--- a/nodemapper/src/gui/Vneyard/Vneyard.tsx
+++ b/nodemapper/src/gui/Vneyard/Vneyard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+const Vineyard = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        width: '100%',
+        height: '100vh',
+      }}
+    >
+      <iframe
+        src="https://kraemer-lab.github.io/vneyard/"
+        style={{
+          width: '100%',
+          height: '100%',
+          border: 'none',
+        }}
+      />
+    </Box>
+  );
+};
+
+export default Vineyard;

--- a/nodemapper/src/gui/Vneyard/Vneyard.tsx
+++ b/nodemapper/src/gui/Vneyard/Vneyard.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Box } from '@mui/material';
+import { useAppSelector } from 'redux/store/hooks';
 
 const Vineyard = () => {
+  const vneyard_url = useAppSelector((state) => state.builder.vneyard_url);
+
   return (
     <Box
       sx={{
@@ -11,7 +14,7 @@ const Vineyard = () => {
       }}
     >
       <iframe
-        src="https://kraemer-lab.github.io/vneyard/"
+        src={vneyard_url}
         style={{
           width: '100%',
           height: '100%',

--- a/nodemapper/src/redux/reducers/builder.ts
+++ b/nodemapper/src/redux/reducers/builder.ts
@@ -66,6 +66,7 @@ export interface IBuilderState {
   hide_params_in_module_info: boolean;
   dark_mode: boolean;
   workflow_alerts: IWorkflowAlerts;
+  vneyard_url: string;
 }
 
 // Defaults
@@ -135,6 +136,7 @@ const builderStateInit: IBuilderState = {
       },
     },
   },
+  vneyard_url: 'https://kraemer-lab.github.io/vneyard/',
 };
 
 // Nodemap


### PR DESCRIPTION
Adds a web-based module search page to GRAPEVNE. This is distinct from the module search that is accessible in the Builder screen which only indexes 'active' (loaded) repositories. The web-based interface should give a broader view across multiple repositories.

In terms of implementation, this links to a [github-pages deployment](https://kraemer-lab.github.io/vneyard/). The page loads the `manifest.json` file from the repository (see https://github.com/kraemer-lab/vneyard/pull/45) and provides a searchable interface which also pulls the module docstrings when modules are selected from the list (see screenshot below). The intention is that the search page will load manifests from multiple repositories, which are listed in a [`repositories.json`](https://github.com/kraemer-lab/vneyard/blob/gh-pages/repositories.json) file (at present there is a single default entry, though it is possible to alter the repositories list live on the page for custom browsing [see screenshot]). The page can act as a general web-accessible module browsing interface, as-well as being incorporated into GRAPEVNE via the side-navigation bar.

This PR adds the side navigation option that opens the module search in an iframe within grapevne. The vneyard URL is stored in redux state so that it can be easily modified / customised in future.

<img width="1030" alt="Screenshot 2024-08-14 at 09 23 56" src="https://github.com/user-attachments/assets/2e426031-d1a9-4d15-90c5-5c55bbe17725">

Resolves #305 