### PR TITLE
Exclude _test rules on workflow imports

### DIFF
--- a/builder/builder/builder.py
+++ b/builder/builder/builder.py
@@ -190,7 +190,7 @@ class Model:
                 s += "        )\n"
             s += "    config:\n"
             s += f'        config["{node.rulename}"]["config"]\n'
-            s += f"use rule * from {node.rulename} as {node.rulename}_*\n"
+            s += f"use rule * from {node.rulename} exclude _test as {node.rulename}_*\n"
             s += self.AddWorkflowAlerts()
         return s
 

--- a/builder/builder/tests/builder_test.py
+++ b/builder/builder/tests/builder_test.py
@@ -37,21 +37,21 @@ module module1:
         config["module1"]["snakefile"]
     config:
         config["module1"]["config"]
-use rule * from module1 as module1_*
+use rule * from module1 exclude _test as module1_*
 
 module module2:
     snakefile:
         config["module2"]["snakefile"]
     config:
         config["module2"]["config"]
-use rule * from module2 as module2_*
+use rule * from module2 exclude _test as module2_*
 
 module module3:
     snakefile:
         config["module3"]["snakefile"]
     config:
         config["module3"]["config"]
-use rule * from module3 as module3_*
+use rule * from module3 exclude _test as module3_*
 """
     assert m.BuildSnakefile() == target_snakefile
 

--- a/builder/builder/tests/workflow_import_test/modules/1srcsleep2in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/1srcsleep2in/workflow/Snakefile
@@ -5,11 +5,11 @@ module source_test1:
         config["source_test1"]["snakefile"]
     config:
         config["source_test1"]["config"]
-use rule * from source_test1 as source_test1_*
+use rule * from source_test1 exclude _test as source_test1_*
 
 module sleep2input_test:
     snakefile:
         config["sleep2input_test"]["snakefile"]
     config:
         config["sleep2input_test"]["config"]
-use rule * from sleep2input_test as sleep2input_test_*
+use rule * from sleep2input_test exclude _test as sleep2input_test_*

--- a/builder/builder/tests/workflow_import_test/modules/2src2sleep2in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/2src2sleep2in/workflow/Snakefile
@@ -5,32 +5,32 @@ module source_test1:
         config["source_test1"]["snakefile"]
     config:
         config["source_test1"]["config"]
-use rule * from source_test1 as source_test1_*
+use rule * from source_test1 exclude _test as source_test1_*
 
 module source_test2:
     snakefile:
         config["source_test2"]["snakefile"]
     config:
         config["source_test2"]["config"]
-use rule * from source_test2 as source_test2_*
+use rule * from source_test2 exclude _test as source_test2_*
 
 module sleep2input_test1:
     snakefile:
         config["sleep2input_test1"]["snakefile"]
     config:
         config["sleep2input_test1"]["config"]
-use rule * from sleep2input_test1 as sleep2input_test1_*
+use rule * from sleep2input_test1 exclude _test as sleep2input_test1_*
 
 module sleep2input_test2:
     snakefile:
         config["sleep2input_test2"]["snakefile"]
     config:
         config["sleep2input_test2"]["config"]
-use rule * from sleep2input_test2 as sleep2input_test2_*
+use rule * from sleep2input_test2 exclude _test as sleep2input_test2_*
 
 module sleep2input_common_out:
     snakefile:
         config["sleep2input_common_out"]["snakefile"]
     config:
         config["sleep2input_common_out"]["config"]
-use rule * from sleep2input_common_out as sleep2input_common_out_*
+use rule * from sleep2input_common_out exclude _test as sleep2input_common_out_*

--- a/builder/builder/tests/workflow_import_test/modules/2srcsleep2in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/2srcsleep2in/workflow/Snakefile
@@ -5,18 +5,18 @@ module source_test1:
         config["source_test1"]["snakefile"]
     config:
         config["source_test1"]["config"]
-use rule * from source_test1 as source_test1_*
+use rule * from source_test1 exclude _test as source_test1_*
 
 module source_test2:
     snakefile:
         config["source_test2"]["snakefile"]
     config:
         config["source_test2"]["config"]
-use rule * from source_test2 as source_test2_*
+use rule * from source_test2 exclude _test as source_test2_*
 
 module sleep2input_test:
     snakefile:
         config["sleep2input_test"]["snakefile"]
     config:
         config["sleep2input_test"]["config"]
-use rule * from sleep2input_test as sleep2input_test_*
+use rule * from sleep2input_test exclude _test as sleep2input_test_*

--- a/builder/builder/tests/workflow_import_test/modules/c2c2sleep1in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/c2c2sleep1in/workflow/Snakefile
@@ -5,25 +5,25 @@ module sleep1input_test1:
         config["sleep1input_test1"]["snakefile"]
     config:
         config["sleep1input_test1"]["config"]
-use rule * from sleep1input_test1 as sleep1input_test1_*
+use rule * from sleep1input_test1 exclude _test as sleep1input_test1_*
 
 module sleep1input_test2:
     snakefile:
         config["sleep1input_test2"]["snakefile"]
     config:
         config["sleep1input_test2"]["config"]
-use rule * from sleep1input_test2 as sleep1input_test2_*
+use rule * from sleep1input_test2 exclude _test as sleep1input_test2_*
 
 module sleep1input_test1_1:
     snakefile:
         config["sleep1input_test1_1"]["snakefile"]
     config:
         config["sleep1input_test1_1"]["config"]
-use rule * from sleep1input_test1_1 as sleep1input_test1_1_*
+use rule * from sleep1input_test1_1 exclude _test as sleep1input_test1_1_*
 
 module sleep1input_test2_1:
     snakefile:
         config["sleep1input_test2_1"]["snakefile"]
     config:
         config["sleep1input_test2_1"]["config"]
-use rule * from sleep1input_test2_1 as sleep1input_test2_1_*
+use rule * from sleep1input_test2_1 exclude _test as sleep1input_test2_1_*

--- a/builder/builder/tests/workflow_import_test/modules/c2sleep1in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/c2sleep1in/workflow/Snakefile
@@ -5,11 +5,11 @@ module sleep1input_test1:
         config["sleep1input_test1"]["snakefile"]
     config:
         config["sleep1input_test1"]["config"]
-use rule * from sleep1input_test1 as sleep1input_test1_*
+use rule * from sleep1input_test1 exclude _test as sleep1input_test1_*
 
 module sleep1input_test2:
     snakefile:
         config["sleep1input_test2"]["snakefile"]
     config:
         config["sleep1input_test2"]["config"]
-use rule * from sleep1input_test2 as sleep1input_test2_*
+use rule * from sleep1input_test2 exclude _test as sleep1input_test2_*

--- a/builder/builder/tests/workflow_import_test/modules/skeleton/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/skeleton/workflow/Snakefile
@@ -6,7 +6,7 @@ module module1:
     config:
         config["module1"]["config"]
 
-use rule * from module1 as module1_*
+use rule * from module1 exclude _test as module1_*
 
 module module2:
     snakefile:
@@ -14,7 +14,7 @@ module module2:
     config:
         config["module2"]["config"]
 
-use rule * from module2 as module2_*
+use rule * from module2 exclude _test as module2_*
 
 module module3:
     snakefile:
@@ -22,4 +22,4 @@ module module3:
     config:
         config["module3"]["config"]
 
-use rule * from module3 as module3_*
+use rule * from module3 exclude _test as module3_*

--- a/builder/builder/tests/workflow_import_test/modules/srcc2sleep1in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/srcc2sleep1in/workflow/Snakefile
@@ -5,18 +5,18 @@ module source_test:
         config["source_test"]["snakefile"]
     config:
         config["source_test"]["config"]
-use rule * from source_test as source_test_*
+use rule * from source_test exclude _test as source_test_*
 
 module sleep1input_test1:
     snakefile:
         config["sleep1input_test1"]["snakefile"]
     config:
         config["sleep1input_test1"]["config"]
-use rule * from sleep1input_test1 as sleep1input_test1_*
+use rule * from sleep1input_test1 exclude _test as sleep1input_test1_*
 
 module sleep1input_test2:
     snakefile:
         config["sleep1input_test2"]["snakefile"]
     config:
         config["sleep1input_test2"]["config"]
-use rule * from sleep1input_test2 as sleep1input_test2_*
+use rule * from sleep1input_test2 exclude _test as sleep1input_test2_*

--- a/builder/builder/tests/workflow_import_test/modules/srcsleep1in/workflow/Snakefile
+++ b/builder/builder/tests/workflow_import_test/modules/srcsleep1in/workflow/Snakefile
@@ -5,11 +5,11 @@ module source_test:
         config["source_test"]["snakefile"]
     config:
         config["source_test"]["config"]
-use rule * from source_test as source_test_*
+use rule * from source_test exclude _test as source_test_*
 
 module sleep1input_test:
     snakefile:
         config["sleep1input_test"]["snakefile"]
     config:
         config["sleep1input_test"]["config"]
-use rule * from sleep1input_test as sleep1input_test_*
+use rule * from sleep1input_test exclude _test as sleep1input_test_*


### PR DESCRIPTION
All rules are imported per module into the workflow. This change excludes the '_test' rule from module imports.